### PR TITLE
Refatorações

### DIFF
--- a/Boleto2.Net.Testes/Banco001_Brasil_11_019.cs
+++ b/Boleto2.Net.Testes/Banco001_Brasil_11_019.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
+    [TestFixture]
     public class Banco001_Brasil_11_019
     {
         Banco banco;
@@ -29,7 +28,7 @@ namespace Boleto2Net.Testes
 
 
         }
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_11_019_TestePendente()
         {
             Assert.Inconclusive("Aguardando boletos de exemplo (gerados pelo banco - segunda via) para implementar os testes:/n" +

--- a/Boleto2.Net.Testes/Banco001_Brasil_17_019.cs
+++ b/Boleto2.Net.Testes/Banco001_Brasil_17_019.cs
@@ -30,7 +30,7 @@ namespace Boleto2Net.Testes
         [Test]
         public void Banco001_Brasil_17_019_REM240()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240,  nameof(Banco001_Brasil_17_019));
+            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco001_Brasil_17_019));
         }
 
         [Test]
@@ -45,190 +45,37 @@ namespace Boleto2Net.Testes
             Utils.TestarBoletoPDF(banco, nameof(Banco001_Brasil_17_019));
         }
 
-        [Test]
-        public void Banco001_Brasil_17_019_DV1()
+        [TestCase(400d, "5", "BO123456E", "1", "12345670000000005", "00191699100000400000000001234567000000000517", "00190.00009 01234.567004 00000.005173 1 69910000040000", 2016, 11, 27)]
+        [TestCase(402d, "5", "BO123456E", "2", "12345670000000005", "00192699100000402000000001234567000000000517", "00190.00009 01234.567004 00000.005173 2 69910000040200", 2016, 11, 27)]
+        [TestCase(200d, "3", "BO123456C", "3", "12345670000000003", "00193692900000200000000001234567000000000317", "00190.00009 01234.567004 00000.003178 3 69290000020000", 2016, 9, 26)]
+        [TestCase(1232.78, "1", "BO123456A", "4", "12345670000000001", "00194688900001232780000001234567000000000117", "00190.00009 01234.567004 00000.001172 4 68890000123278", 2016, 8, 17)]
+        [TestCase(800, "9", "BO123456I", "5", "12345670000000009", "00195710300000800000000001234567000000000917", "00190.00009 01234.567004 00000.009175 5 71030000080000", 2017, 3, 19)]
+        [TestCase(306.52, "4", "BO123456D", "6", "12345670000000004", "00196695900000306520000001234567000000000417", "00190.00009 01234.567004 00000.004176 6 69590000030652", 2016, 10, 26)]
+        [TestCase(300, "4", "BO123456D", "7", "12345670000000004", "00197695900000300000000001234567000000000417", "00190.00009 01234.567004 00000.004176 7 69590000030000", 2016, 10, 26)]
+        [TestCase(609, "7", "BO123456G", "8", "12345670000000007", "00198705200000609000000001234567000000000717", "00190.00009 01234.567004 00000.007179 8 70520000060900", 2017, 1, 27)]
+        [TestCase(600, "7", "BO123456G", "9", "12345670000000007", "00199705200000600000000001234567000000000717", "00190.00009 01234.567004 00000.007179 9 70520000060000", 2017, 1, 27)]
+        public void GeraUmBoletoValido(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
+            //Ambiente
             var boleto = new Boleto
             {
-                DataVencimento = new DateTime(2016, 11, 27),
-                ValorTitulo = (decimal)400,
-                NossoNumero = "5",
-                NumeroDocumento = "BO123456E",
+                DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
+                ValorTitulo = valorTitulo,
+                NossoNumero = nossoNumero,
+                NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
                 Banco = banco,
                 Sacado = Utils.GerarSacado()
             };
+
+            //Ação
             boleto.ValidarDados();
-            Assert.AreEqual("1", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 1");
-            Assert.AreEqual("12345670000000005", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00191699100000400000000001234567000000000517", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.005173 1 69910000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+
+            //Assertivas
+            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
+            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
+            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV2()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 11, 27),
-                ValorTitulo = (decimal)402,
-                NossoNumero = "5",
-                NumeroDocumento = "BO123456E",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("2", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 2");
-            Assert.AreEqual("12345670000000005", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00192699100000402000000001234567000000000517", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.005173 2 69910000040200", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV3()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 9, 26),
-                ValorTitulo = (decimal)200,
-                NossoNumero = "3",
-                NumeroDocumento = "BO123456C",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("3", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 3");
-            Assert.AreEqual("12345670000000003", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00193692900000200000000001234567000000000317", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.003178 3 69290000020000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV4()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 8, 17),
-                ValorTitulo = (decimal)1232.78,
-                NossoNumero = "1",
-                NumeroDocumento = "BO123456A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("4", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 4");
-            Assert.AreEqual("12345670000000001", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00194688900001232780000001234567000000000117", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.001172 4 68890000123278", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV5()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 3, 19),
-                ValorTitulo = (decimal)800,
-                NossoNumero = "9",
-                NumeroDocumento = "BO123456I",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("5", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 5");
-            Assert.AreEqual("12345670000000009", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00195710300000800000000001234567000000000917", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.009175 5 71030000080000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV6()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 10, 26),
-                ValorTitulo = (decimal)306.52,
-                NossoNumero = "4",
-                NumeroDocumento = "BO123456D",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("6", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 6");
-            Assert.AreEqual("12345670000000004", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00196695900000306520000001234567000000000417", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.004176 6 69590000030652", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV7()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 10, 26),
-                ValorTitulo = (decimal)300,
-                NossoNumero = "4",
-                NumeroDocumento = "BO123456D",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("7", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 7");
-            Assert.AreEqual("12345670000000004", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00197695900000300000000001234567000000000417", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.004176 7 69590000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV8()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 1, 27),
-                ValorTitulo = (decimal)609,
-                NossoNumero = "7",
-                NumeroDocumento = "BO123456G",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("8", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador Diferente de 8");
-            Assert.AreEqual("12345670000000007", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00198705200000609000000001234567000000000717", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.007179 8 70520000060900", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco001_Brasil_17_019_DV9()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 1, 27),
-                ValorTitulo = (decimal)600,
-                NossoNumero = "7",
-                NumeroDocumento = "BO123456G",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("9", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 9");
-            Assert.AreEqual("12345670000000007", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("00199705200000600000000001234567000000000717", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("00190.00009 01234.567004 00000.007179 9 70520000060000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
     }
 }

--- a/Boleto2.Net.Testes/Banco001_Brasil_17_019.cs
+++ b/Boleto2.Net.Testes/Banco001_Brasil_17_019.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Banco001_Brasil_17_019
     {
         Banco banco;
@@ -29,25 +27,25 @@ namespace Boleto2Net.Testes
             banco.FormataCedente();
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_REM240()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240,  nameof(Banco001_Brasil_17_019));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_REM400()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco001_Brasil_17_019));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_PDF()
         {
             Utils.TestarBoletoPDF(banco, nameof(Banco001_Brasil_17_019));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV1()
         {
             var boleto = new Boleto
@@ -67,7 +65,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("00190.00009 01234.567004 00000.005173 1 69910000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV2()
         {
             var boleto = new Boleto
@@ -87,7 +85,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("00190.00009 01234.567004 00000.005173 2 69910000040200", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV3()
         {
             var boleto = new Boleto
@@ -107,7 +105,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("00190.00009 01234.567004 00000.003178 3 69290000020000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV4()
         {
             var boleto = new Boleto
@@ -127,7 +125,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("00190.00009 01234.567004 00000.001172 4 68890000123278", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV5()
         {
             var boleto = new Boleto
@@ -149,7 +147,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV6()
         {
             var boleto = new Boleto
@@ -171,7 +169,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV7()
         {
             var boleto = new Boleto
@@ -192,7 +190,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV8()
         {
             var boleto = new Boleto
@@ -212,7 +210,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("00190.00009 01234.567004 00000.007179 8 70520000060900", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco001_Brasil_17_019_DV9()
         {
             var boleto = new Boleto

--- a/Boleto2.Net.Testes/Banco237_Bradesco_09.cs
+++ b/Boleto2.Net.Testes/Banco237_Bradesco_09.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Banco237_Bradesco_09
     {
         Banco banco;
@@ -27,20 +26,20 @@ namespace Boleto2Net.Testes
             banco.FormataCedente();
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_REM400()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco237_Bradesco_09));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_PDF()
         {
             Utils.TestarBoletoPDF(banco, nameof(Banco237_Bradesco_09));
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV1()
         {
             var boleto = new Boleto
@@ -60,7 +59,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("23791.23405 90000.000043 53012.345608 1 69040000014150", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV2()
         {
             var boleto = new Boleto
@@ -80,7 +79,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("23791.23405 90000.000043 56012.345601 2 69340000271716", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV3()
         {
             var boleto = new Boleto
@@ -100,7 +99,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("23791.23405 90000.000043 44012.345607 3 69050000029721", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV4()
         {
             var boleto = new Boleto
@@ -121,7 +120,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV5()
         {
             var boleto = new Boleto
@@ -142,7 +141,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV6()
         {
             var boleto = new Boleto
@@ -162,7 +161,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("23791.23405 90000.000043 14012.345600 6 68730000064939", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV7()
         {
             var boleto = new Boleto
@@ -183,7 +182,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV8()
         {
             var boleto = new Boleto
@@ -203,7 +202,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("23791.23405 90000.000043 45012.345604 8 69050000292411", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco237_Bradesco_09_DV9()
         {
             var boleto = new Boleto

--- a/Boleto2.Net.Testes/Banco237_Bradesco_09.cs
+++ b/Boleto2.Net.Testes/Banco237_Bradesco_09.cs
@@ -38,189 +38,37 @@ namespace Boleto2Net.Testes
             Utils.TestarBoletoPDF(banco, nameof(Banco237_Bradesco_09));
         }
 
-
-        [Test]
-        public void Banco237_Bradesco_09_DV1()
+        [TestCase(141.50, "453", "BB943A", "1", "09/00000000453-P", "23791690400000141501234090000000045301234560", "23791.23405 90000.000043 53012.345608 1 69040000014150", 2016, 9, 1)]
+        [TestCase(2717.16, "456", "BB874A", "2", "09/00000000456-4", "23792693400002717161234090000000045601234560", "23791.23405 90000.000043 56012.345601 2 69340000271716", 2016, 10, 1)]
+        [TestCase(297.21, "444", "BB834A", "3", "09/00000000444-0", "23793690500000297211234090000000044401234560", "23791.23405 90000.000043 44012.345607 3 69050000029721", 2016, 9, 2)]
+        [TestCase(297.21, "468", "BB856A", "4", "09/00000000468-8", "23794693500000297211234090000000046801234560", "23791.23405 90000.000043 68012.345606 4 69350000029721", 2016, 10, 2)]
+        [TestCase(297.21, "443", "BB833A", "5", "09/00000000443-2", "23795690500000297211234090000000044301234560", "23791.23405 90000.000043 43012.345609 5 69050000029721", 2016, 9, 2)]
+        [TestCase(649.39, "414", "BB815A", "6", "09/00000000414-9", "23796687300000649391234090000000041401234560", "23791.23405 90000.000043 14012.345600 6 68730000064939", 2016, 8, 1)]
+        [TestCase(270, "561", "BB932A", "7", "09/00000000561-7", "23797702600000270001234090000000056101234560", "23791.23405 90000.000050 61012.345601 7 70260000027000", 2017, 1, 1)]
+        [TestCase(2924.11, "445", "BB874A", "8", "09/00000000445-9", "23798690500002924111234090000000044501234560", "23791.23405 90000.000043 45012.345604 8 69050000292411", 2016, 9, 2)]
+        [TestCase(830, "562", "BB933A", "9", "09/00000000562-5", "23799702600000830001234090000000056201234560", "23791.23405 90000.000050 62012.345609 9 70260000083000", 2017, 1, 1)]
+        public void GeraUmBoletoValido(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
+            //Ambiente
             var boleto = new Boleto
             {
-                DataVencimento = new DateTime(2016, 9, 1),
-                ValorTitulo = (decimal)141.50,
-                NossoNumero = "453",
-                NumeroDocumento = "BB943A",
+                DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
+                ValorTitulo = valorTitulo,
+                NossoNumero = nossoNumero,
+                NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
                 Banco = banco,
                 Sacado = Utils.GerarSacado()
             };
+
+            //Ação
             boleto.ValidarDados();
-            Assert.AreEqual("1", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 1");
-            Assert.AreEqual("09/00000000453-P", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23791690400000141501234090000000045301234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 53012.345608 1 69040000014150", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+
+            //Assertivas
+            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
+            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
+            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
-
-        [Test]
-        public void Banco237_Bradesco_09_DV2()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 10, 1),
-                ValorTitulo = (decimal)2717.16,
-                NossoNumero = "456",
-                NumeroDocumento = "BB874A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("2", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 2");
-            Assert.AreEqual("09/00000000456-4", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23792693400002717161234090000000045601234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 56012.345601 2 69340000271716", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco237_Bradesco_09_DV3()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 9, 2),
-                ValorTitulo = (decimal)297.21,
-                NossoNumero = "444",
-                NumeroDocumento = "BB834A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("3", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 3");
-            Assert.AreEqual("09/00000000444-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23793690500000297211234090000000044401234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 44012.345607 3 69050000029721", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco237_Bradesco_09_DV4()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 10, 2),
-                ValorTitulo = (decimal)297.21,
-                NossoNumero = "468",
-                NumeroDocumento = "BB856A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("4", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 4");
-            Assert.AreEqual("09/00000000468-8", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23794693500000297211234090000000046801234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 68012.345606 4 69350000029721", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco237_Bradesco_09_DV5()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 9, 2),
-                ValorTitulo = (decimal)297.21,
-                NossoNumero = "443",
-                NumeroDocumento = "BB833A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("5", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 5");
-            Assert.AreEqual("09/00000000443-2", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23795690500000297211234090000000044301234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 43012.345609 5 69050000029721", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco237_Bradesco_09_DV6()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 8, 1),
-                ValorTitulo = (decimal)649.39,
-                NossoNumero = "414",
-                NumeroDocumento = "BB815A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("6", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 6");
-            Assert.AreEqual("09/00000000414-9", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23796687300000649391234090000000041401234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 14012.345600 6 68730000064939", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco237_Bradesco_09_DV7()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 1, 1),
-                ValorTitulo = (decimal)270,
-                NossoNumero = "561",
-                NumeroDocumento = "BB932A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("7", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 7");
-            Assert.AreEqual("09/00000000561-7", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23797702600000270001234090000000056101234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000050 61012.345601 7 70260000027000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco237_Bradesco_09_DV8()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 9, 2),
-                ValorTitulo = (decimal)2924.11,
-                NossoNumero = "445",
-                NumeroDocumento = "BB874A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("8", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 8");
-            Assert.AreEqual("09/00000000445-9", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23798690500002924111234090000000044501234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000043 45012.345604 8 69050000292411", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco237_Bradesco_09_DV9()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 1, 1),
-                ValorTitulo = (decimal)830,
-                NossoNumero = "562",
-                NumeroDocumento = "BB933A",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("9", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 9");
-            Assert.AreEqual("09/00000000562-5", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("23799702600000830001234090000000056201234560", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("23791.23405 90000.000050 62012.345609 9 70260000083000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
     }
 }

--- a/Boleto2.Net.Testes/Banco756_Sicoob_1_01.cs
+++ b/Boleto2.Net.Testes/Banco756_Sicoob_1_01.cs
@@ -32,6 +32,7 @@ namespace Boleto2Net.Testes
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco756_Sicoob_1_01));
         }
+
         [Test]
         public void Banco756_Sicoob_1_01_REM400()
         {
@@ -44,190 +45,37 @@ namespace Boleto2Net.Testes
             Utils.TestarBoletoPDF(banco, nameof(Banco756_Sicoob_1_01));
         }
 
-        [Test]
-        public void Banco756_Sicoob_1_01_DV1()
+        [TestCase(300, "4", "BO123456D", "1", "0000004-0", "75691697400000300001427701017227800000040001", "75691.42776 01017.227800 00000.400010 1 69740000030000", 2016, 11, 10)]
+        [TestCase(300, "3", "BO123456D", "2", "0000003-3", "75692711100000300001427701017227800000033001", "75691.42776 01017.227800 00000.330019 2 71110000030000", 2017, 03, 27)]
+        [TestCase(400, "4", "BO123456D", "3", "0000004-0", "75693714200000400001427701017227800000040001", "75691.42776 01017.227800 00000.400010 3 71420000040000", 2017, 04, 27)]
+        [TestCase(500, "6", "BO123456F", "4", "0000006-5", "75694703000000500001427701017227800000065001", "75691.42776 01017.227800 00000.650010 4 70300000050000", 2017, 01, 05)]
+        [TestCase(900, "9", "BO123456F", "5", "0000009-7", "75695729500000900001427701017227800000097001", "75691.42776 01017.227800 00000.970012 5 72950000090000", 2017, 09, 27)]
+        [TestCase(600, "7", "BO123456G", "6", "0000007-2", "75696706300000600001427701017227800000072001", "75691.42776 01017.227800 00000.720011 6 70630000060000", 2017, 2, 07)]
+        [TestCase(4011.24, "12349", "BO123456F", "7", "0012349-2", "75697702200004011241427701017227800123492001", "75691.42776 01017.227800 01234.920013 7 70220000401124", 2016, 12, 28)]
+        [TestCase(700, "8", "BO123456B", "8", "0000008-0", "75698709500000700001427701017227800000080001", "75691.42776 01017.227800 00000.800011 8 70950000070000", 2017, 3, 11)]
+        [TestCase(409, "5", "BO123456E", "9", "0000005-8", "75699700200000409001427701017227800000058001", "75691.42776 01017.227800 00000.580019 9 70020000040900", 2016, 12, 08)]
+        public void GeraUmBoletoValido(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
+            //Ambiente
             var boleto = new Boleto
             {
-                DataVencimento = new DateTime(2016, 11, 10),
-                ValorTitulo = (decimal)300,
-                NossoNumero = "4",
-                NumeroDocumento = "BO123456D",
+                DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
+                ValorTitulo = valorTitulo,
+                NossoNumero = nossoNumero,
+                NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
                 Banco = banco,
                 Sacado = Utils.GerarSacado()
             };
+
+            //Ação
             boleto.ValidarDados();
-            Assert.AreEqual("1", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 1");
-            Assert.AreEqual("0000004-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75691697400000300001427701017227800000040001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.400010 1 69740000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+
+            //Assertivas
+            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
+            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
+            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV2()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 03, 27),
-                ValorTitulo = (decimal)300,
-                NossoNumero = "3",
-                NumeroDocumento = "BO123456D",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("2", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 2");
-            Assert.AreEqual("0000003-3", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75692711100000300001427701017227800000033001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.330019 2 71110000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV3()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 04, 27),
-                ValorTitulo = (decimal)400,
-                NossoNumero = "4",
-                NumeroDocumento = "BO123456D",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("3", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 3");
-            Assert.AreEqual("0000004-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75693714200000400001427701017227800000040001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.400010 3 71420000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV4()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 01, 05),
-                ValorTitulo = (decimal)500,
-                NossoNumero = "6",
-                NumeroDocumento = "BO123456F",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("4", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 4");
-            Assert.AreEqual("0000006-5", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75694703000000500001427701017227800000065001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.650010 4 70300000050000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV5()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 09, 27),
-                ValorTitulo = (decimal)900,
-                NossoNumero = "9",
-                NumeroDocumento = "BO123456F",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("5", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 5");
-            Assert.AreEqual("0000009-7", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75695729500000900001427701017227800000097001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.970012 5 72950000090000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV6()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 2, 07),
-                ValorTitulo = (decimal)600,
-                NossoNumero = "7",
-                NumeroDocumento = "BO123456G",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("6", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 6");
-            Assert.AreEqual("0000007-2", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75696706300000600001427701017227800000072001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.720011 6 70630000060000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV7()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 12, 28),
-                ValorTitulo = (decimal)4011.24,
-                NossoNumero = "12349",
-                NumeroDocumento = "BO123456F",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("7", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 7");
-            Assert.AreEqual("0012349-2", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75697702200004011241427701017227800123492001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 01234.920013 7 70220000401124", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV8()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 3, 11),
-                ValorTitulo = (decimal)700,
-                NossoNumero = "8",
-                NumeroDocumento = "BO123456B",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("8", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 8");
-            Assert.AreEqual("0000008-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75698709500000700001427701017227800000080001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.800011 8 70950000070000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco756_Sicoob_1_01_DV9()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 12, 08),
-                ValorTitulo = (decimal)409,
-                NossoNumero = "5",
-                NumeroDocumento = "BO123456E",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("9", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 9");
-            Assert.AreEqual("0000005-8", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("75699700200000409001427701017227800000058001", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("75691.42776 01017.227800 00000.580019 9 70020000040900", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
     }
 }

--- a/Boleto2.Net.Testes/Banco756_Sicoob_1_01.cs
+++ b/Boleto2.Net.Testes/Banco756_Sicoob_1_01.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Banco756_Sicoob_1_01
     {
         Banco banco;
@@ -28,24 +27,24 @@ namespace Boleto2Net.Testes
             banco.FormataCedente();
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_REM240()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco756_Sicoob_1_01));
         }
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_REM400()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco756_Sicoob_1_01));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_PDF()
         {
             Utils.TestarBoletoPDF(banco, nameof(Banco756_Sicoob_1_01));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV1()
         {
             var boleto = new Boleto
@@ -65,7 +64,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("75691.42776 01017.227800 00000.400010 1 69740000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV2()
         {
             var boleto = new Boleto
@@ -85,7 +84,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("75691.42776 01017.227800 00000.330019 2 71110000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV3()
         {
             var boleto = new Boleto
@@ -105,7 +104,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("75691.42776 01017.227800 00000.400010 3 71420000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV4()
         {
             var boleto = new Boleto
@@ -127,7 +126,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV5()
         {
             var boleto = new Boleto
@@ -148,7 +147,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV6()
         {
             var boleto = new Boleto
@@ -168,7 +167,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("75691.42776 01017.227800 00000.720011 6 70630000060000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV7()
         {
             var boleto = new Boleto
@@ -189,7 +188,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV8()
         {
             var boleto = new Boleto
@@ -210,7 +209,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco756_Sicoob_1_01_DV9()
         {
             var boleto = new Boleto

--- a/Boleto2.Net.Testes/BancoBradescoCarteira09.cs
+++ b/Boleto2.Net.Testes/BancoBradescoCarteira09.cs
@@ -3,10 +3,10 @@ using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Banco237_Bradesco_09
+    public class BancoBradescoCarteira09
     {
-        Banco banco;
-        public Banco237_Bradesco_09()
+        readonly Banco _banco;
+        public BancoBradescoCarteira09()
         {
             var contaBancaria = new ContaBancaria
             {
@@ -19,23 +19,23 @@ namespace Boleto2Net.Testes
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
-            banco = new Banco(237)
+            _banco = new Banco(237)
             {
                 Cedente = Utils.GerarCedente("1213141", "", contaBancaria)
             };
-            banco.FormataCedente();
+            _banco.FormataCedente();
         }
 
         [Test]
         public void Banco237_Bradesco_09_REM400()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco237_Bradesco_09));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB400, nameof(BancoBradescoCarteira09));
         }
 
         [Test]
         public void Banco237_Bradesco_09_PDF()
         {
-            Utils.TestarBoletoPDF(banco, nameof(Banco237_Bradesco_09));
+            Utils.TestarBoletoPDF(_banco, nameof(BancoBradescoCarteira09));
         }
 
         [TestCase(141.50, "453", "BB943A", "1", "09/00000000453-P", "23791690400000141501234090000000045301234560", "23791.23405 90000.000043 53012.345608 1 69040000014150", 2016, 9, 1)]
@@ -57,7 +57,7 @@ namespace Boleto2Net.Testes
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
+                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 
@@ -65,10 +65,10 @@ namespace Boleto2Net.Testes
             boleto.ValidarDados();
 
             //Assertivas
-            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
-            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+            Assert.That(boleto.CodigoBarra.DigitoVerificador, Is.EqualTo(digitoVerificador), $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.That(boleto.NossoNumeroFormatado, Is.EqualTo(nossoNumeroFormatado), "Nosso número inválido");
+            Assert.That(boleto.CodigoBarra.CodigoDeBarras, Is.EqualTo(codigoDeBarras), "Código de Barra inválido");
+            Assert.That(boleto.CodigoBarra.LinhaDigitavel, Is.EqualTo(linhaDigitavel), "Linha digitável inválida");
         }
     }
 }

--- a/Boleto2.Net.Testes/BancoBrasilCarteira11_019Tests.cs
+++ b/Boleto2.Net.Testes/BancoBrasilCarteira11_019Tests.cs
@@ -3,10 +3,10 @@
 namespace Boleto2Net.Testes
 {
     [TestFixture]
-    public class Banco001_Brasil_11_019
+    public class BancoBrasilCarteira11019Tests
     {
-        Banco banco;
-        public Banco001_Brasil_11_019()
+        readonly Banco _banco;
+        public BancoBrasilCarteira11019Tests()
         {
             var contaBancaria = new ContaBancaria
             {
@@ -20,11 +20,11 @@ namespace Boleto2Net.Testes
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
-            banco = new Banco(001)
+            _banco = new Banco(001)
             {
                 Cedente = Utils.GerarCedente("1234567", "", contaBancaria)
             };
-            banco.FormataCedente();
+            _banco.FormataCedente();
 
 
         }

--- a/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
+++ b/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
@@ -3,10 +3,10 @@ using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Banco001_Brasil_17_019
+    public class BancoBrasilCarteira17019Tests
     {
-        Banco banco;
-        public Banco001_Brasil_17_019()
+        readonly Banco _banco;
+        public BancoBrasilCarteira17019Tests()
         {
             var contaBancaria = new ContaBancaria
             {
@@ -20,29 +20,29 @@ namespace Boleto2Net.Testes
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
-            banco = new Banco(001)
+            _banco = new Banco(001)
             {
                 Cedente = Utils.GerarCedente("1234567", "", contaBancaria)
             };
-            banco.FormataCedente();
+            _banco.FormataCedente();
         }
 
         [Test]
         public void Banco001_Brasil_17_019_REM240()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco001_Brasil_17_019));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB240, nameof(BancoBrasilCarteira17019Tests));
         }
 
         [Test]
         public void Banco001_Brasil_17_019_REM400()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco001_Brasil_17_019));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB400, nameof(BancoBrasilCarteira17019Tests));
         }
 
         [Test]
         public void Banco001_Brasil_17_019_PDF()
         {
-            Utils.TestarBoletoPDF(banco, nameof(Banco001_Brasil_17_019));
+            Utils.TestarBoletoPDF(_banco, nameof(BancoBrasilCarteira17019Tests));
         }
 
         [TestCase(400d, "5", "BO123456E", "1", "12345670000000005", "00191699100000400000000001234567000000000517", "00190.00009 01234.567004 00000.005173 1 69910000040000", 2016, 11, 27)]
@@ -64,7 +64,7 @@ namespace Boleto2Net.Testes
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
+                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 
@@ -72,10 +72,10 @@ namespace Boleto2Net.Testes
             boleto.ValidarDados();
 
             //Assertivas
-            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
-            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+            Assert.That(boleto.CodigoBarra.DigitoVerificador, Is.EqualTo(digitoVerificador), $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.That(boleto.NossoNumeroFormatado, Is.EqualTo(nossoNumeroFormatado), "Nosso número inválido");
+            Assert.That(boleto.CodigoBarra.CodigoDeBarras, Is.EqualTo(codigoDeBarras), "Código de Barra inválido");
+            Assert.That(boleto.CodigoBarra.LinhaDigitavel, Is.EqualTo(linhaDigitavel), "Linha digitável inválida");
         }
     }
 }

--- a/Boleto2.Net.Testes/BancoCaixaCarteiraSig14Tests.cs
+++ b/Boleto2.Net.Testes/BancoCaixaCarteiraSig14Tests.cs
@@ -3,11 +3,11 @@ using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Banco104_Caixa_SIG14
+    public class BancoCaixaCarteiraSig14Tests
     {
-        Banco banco;
+        readonly Banco _banco;
 
-        public Banco104_Caixa_SIG14()
+        public BancoCaixaCarteiraSig14Tests()
         {
             var contaBancaria = new ContaBancaria
             {
@@ -20,23 +20,23 @@ namespace Boleto2Net.Testes
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
-            banco = new Banco(104)
+            _banco = new Banco(104)
             {
                 Cedente = Utils.GerarCedente("123456", "0", contaBancaria)
             };
-            banco.FormataCedente();
+            _banco.FormataCedente();
         }
 
         [Test]
         public void Banco104_Caixa_SIG14_REM240()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco104_Caixa_SIG14));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB240, nameof(BancoCaixaCarteiraSig14Tests));
         }
 
         [Test]
         public void Banco104_Caixa_SIG14_PDF()
         {
-            Utils.TestarBoletoPDF(banco, nameof(Banco104_Caixa_SIG14));
+            Utils.TestarBoletoPDF(_banco, nameof(BancoCaixaCarteiraSig14Tests));
         }
 
         [TestCase(500, "6", "BO123456F", "1", "14000000000000006-5", "10491703000000500001234560000100040000000064", "10491.23456 60000.100044 00000.000646 1 70300000050000", 2017, 01, 05)]
@@ -58,7 +58,7 @@ namespace Boleto2Net.Testes
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
+                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 
@@ -66,10 +66,10 @@ namespace Boleto2Net.Testes
             boleto.ValidarDados();
 
             //Assertivas
-            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
-            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+            Assert.That(boleto.CodigoBarra.DigitoVerificador, Is.EqualTo(digitoVerificador), $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.That(boleto.NossoNumeroFormatado, Is.EqualTo(nossoNumeroFormatado), "Nosso número inválido");
+            Assert.That(boleto.CodigoBarra.CodigoDeBarras, Is.EqualTo(codigoDeBarras), "Código de Barra inválido");
+            Assert.That(boleto.CodigoBarra.LinhaDigitavel, Is.EqualTo(linhaDigitavel), "Linha digitável inválida");
         }
     }
 }

--- a/Boleto2.Net.Testes/BancoSicoobCarteira1_01Tests.cs
+++ b/Boleto2.Net.Testes/BancoSicoobCarteira1_01Tests.cs
@@ -3,10 +3,10 @@ using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Banco756_Sicoob_1_01
+    public class BancoSicoobCarteira101Tests
     {
-        Banco banco;
-        public Banco756_Sicoob_1_01()
+        readonly Banco _banco;
+        public BancoSicoobCarteira101Tests()
         {
             var contaBancaria = new ContaBancaria
             {
@@ -20,29 +20,29 @@ namespace Boleto2Net.Testes
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
-            banco = new Banco(756)
+            _banco = new Banco(756)
             {
                 Cedente = Utils.GerarCedente("17227", "8", contaBancaria)
             };
-            banco.FormataCedente();
+            _banco.FormataCedente();
         }
 
         [Test]
         public void Banco756_Sicoob_1_01_REM240()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco756_Sicoob_1_01));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB240, nameof(BancoSicoobCarteira101Tests));
         }
 
         [Test]
         public void Banco756_Sicoob_1_01_REM400()
         {
-            Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB400, nameof(Banco756_Sicoob_1_01));
+            Utils.TestarArquivoRemessa(_banco, TipoArquivo.CNAB400, nameof(BancoSicoobCarteira101Tests));
         }
 
         [Test]
         public void Banco756_Sicoob_1_01_PDF()
         {
-            Utils.TestarBoletoPDF(banco, nameof(Banco756_Sicoob_1_01));
+            Utils.TestarBoletoPDF(_banco, nameof(BancoSicoobCarteira101Tests));
         }
 
         [TestCase(300, "4", "BO123456D", "1", "0000004-0", "75691697400000300001427701017227800000040001", "75691.42776 01017.227800 00000.400010 1 69740000030000", 2016, 11, 10)]
@@ -64,7 +64,7 @@ namespace Boleto2Net.Testes
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
+                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 
@@ -72,10 +72,10 @@ namespace Boleto2Net.Testes
             boleto.ValidarDados();
 
             //Assertivas
-            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
-            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+            Assert.That(boleto.CodigoBarra.DigitoVerificador, Is.EqualTo(digitoVerificador), $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.That(boleto.NossoNumeroFormatado, Is.EqualTo(nossoNumeroFormatado), "Nosso número inválido");
+            Assert.That(boleto.CodigoBarra.CodigoDeBarras, Is.EqualTo(codigoDeBarras), "Código de Barra inválido");
+            Assert.That(boleto.CodigoBarra.LinhaDigitavel, Is.EqualTo(linhaDigitavel), "Linha digitável inválida");
         }
     }
 }

--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
@@ -46,6 +46,10 @@
       <HintPath>..\packages\NReco.PdfGenerator.1.1.12.0\lib\net20\NReco.PdfGenerator.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>
@@ -55,11 +59,7 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="Banco001_Brasil_11_019.cs" />

--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
@@ -62,11 +62,11 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Compile Include="Banco001_Brasil_11_019.cs" />
-    <Compile Include="Banco001_Brasil_17_019.cs" />
-    <Compile Include="Banco756_Sicoob_1_01.cs" />
-    <Compile Include="CaixaEconomicaFederal_SIG14.cs" />
-    <Compile Include="Banco237_Bradesco_09.cs" />
+    <Compile Include="BancoBrasilCarteira11_019Tests.cs" />
+    <Compile Include="BancoBrasilCarteira17_019Tests.cs" />
+    <Compile Include="BancoSicoobCarteira1_01Tests.cs" />
+    <Compile Include="BancoCaixaCarteiraSig14Tests.cs" />
+    <Compile Include="BancoBradescoCarteira09.cs" />
     <Compile Include="FatorVencimento.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ExemploClasseProxy.cs" />

--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.v3.ncrunchproject
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Boleto2.Net.Testes/CaixaEconomicaFederal_SIG14.cs
+++ b/Boleto2.Net.Testes/CaixaEconomicaFederal_SIG14.cs
@@ -6,6 +6,7 @@ namespace Boleto2Net.Testes
     public class Banco104_Caixa_SIG14
     {
         Banco banco;
+
         public Banco104_Caixa_SIG14()
         {
             var contaBancaria = new ContaBancaria
@@ -38,193 +39,37 @@ namespace Boleto2Net.Testes
             Utils.TestarBoletoPDF(banco, nameof(Banco104_Caixa_SIG14));
         }
 
-
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV1()
+        [TestCase(500, "6", "BO123456F", "1", "14000000000000006-5", "10491703000000500001234560000100040000000064", "10491.23456 60000.100044 00000.000646 1 70300000050000", 2017, 01, 05)]
+        [TestCase(300, "4", "BO123456D", "2", "14000000000000004-9", "10492697400000300001234560000100040000000048", "10491.23456 60000.100044 00000.000489 2 69740000030000", 2016, 11, 10)]
+        [TestCase(409, "5", "BO123456E", "3", "14000000000000005-7", "10493700200000409001234560000100040000000056", "10491.23456 60000.100044 00000.000562 3 70020000040900", 2016, 12, 08)]
+        [TestCase(400, "5", "BO123456E", "4", "14000000000000005-7", "10494700200000400001234560000100040000000056", "10491.23456 60000.100044 00000.000562 4 70020000040000", 2016, 12, 08)]
+        [TestCase(700, "8", "BO123456B", "5", "14000000000000008-1", "10495709500000700001234560000100040000000080", "10491.23456 60000.100044 00000.000802 5 70950000070000", 2017, 3, 11)]
+        [TestCase(600, "7", "BO123456G", "6", "14000000000000007-3", "10496706300000600001234560000100040000000072", "10491.23456 60000.100044 00000.000729 6 70630000060000", 2017, 2, 07)]
+        [TestCase(800, "9", "BO123456B", "7", "14000000000000009-0", "10497711500000800001234560000100040000000099", "10491.23456 60000.100044 00000.000992 7 71150000080000", 2017, 3, 31)]
+        [TestCase(100, "2", "BO123456B", "8", "14000000000000002-2", "10498691800000100001234560000100040000000021", "10491.23456 60000.100044 00000.000216 8 69180000010000", 2016, 9, 15)]
+        [TestCase(200, "3", "BO123456C", "9", "14000000000000003-0", "10499694700000200001234560000100040000000030", "10491.23456 60000.100044 00000.000307 9 69470000020000", 2016, 10, 14)]
+        public void GeraUmBoletoValido(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
+            //Ambiente
             var boleto = new Boleto
             {
-                DataVencimento = new DateTime(2017, 01, 05),
-                ValorTitulo = (decimal)500,
-                NossoNumero = "6",
-                NumeroDocumento = "BO123456F",
+                DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
+                ValorTitulo = valorTitulo,
+                NossoNumero = nossoNumero,
+                NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
                 Banco = banco,
                 Sacado = Utils.GerarSacado()
             };
+
+            //Ação
             boleto.ValidarDados();
-            Assert.AreEqual("1", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 1");
-            Assert.AreEqual("14000000000000006-5", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10491703000000500001234560000100040000000064", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000646 1 70300000050000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
+
+            //Assertivas
+            Assert.AreEqual(digitoVerificador, boleto.CodigoBarra.DigitoVerificador, $"Dígito Verificador diferente de {digitoVerificador}");
+            Assert.AreEqual(nossoNumeroFormatado, boleto.NossoNumeroFormatado, "Nosso número inválido");
+            Assert.AreEqual(codigoDeBarras, boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
+            Assert.AreEqual(linhaDigitavel, boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV2()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 11, 10),
-                ValorTitulo = (decimal)300,
-                NossoNumero = "4",
-                NumeroDocumento = "BO123456D",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("2", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 2");
-            Assert.AreEqual("14000000000000004-9", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10492697400000300001234560000100040000000048", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000489 2 69740000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV3()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 12, 08),
-                ValorTitulo = (decimal)409,
-                NossoNumero = "5",
-                NumeroDocumento = "BO123456E",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("3", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 3");
-            Assert.AreEqual("14000000000000005-7", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10493700200000409001234560000100040000000056", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000562 3 70020000040900", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV4()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 12, 08),
-                ValorTitulo = (decimal)400,
-                NossoNumero = "5",
-                NumeroDocumento = "BO123456E",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("4", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 4");
-            Assert.AreEqual("14000000000000005-7", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10494700200000400001234560000100040000000056", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000562 4 70020000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV5()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 3, 11),
-                ValorTitulo = (decimal)700,
-                NossoNumero = "8",
-                NumeroDocumento = "BO123456B",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("5", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 5");
-            Assert.AreEqual("14000000000000008-1", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10495709500000700001234560000100040000000080", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000802 5 70950000070000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV6()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 2, 07),
-                ValorTitulo = (decimal)600,
-                NossoNumero = "7",
-                NumeroDocumento = "BO123456G",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("6", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 6");
-            Assert.AreEqual("14000000000000007-3", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10496706300000600001234560000100040000000072", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000729 6 70630000060000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV7()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2017, 3, 31),
-                ValorTitulo = (decimal)800,
-                NossoNumero = "9",
-                NumeroDocumento = "BO123456B",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("7", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 7");
-            Assert.AreEqual("14000000000000009-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10497711500000800001234560000100040000000099", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000992 7 71150000080000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV8()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 9, 15),
-                ValorTitulo = (decimal)100,
-                NossoNumero = "2",
-                NumeroDocumento = "BO123456B",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("8", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 8");
-            Assert.AreEqual("14000000000000002-2", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10498691800000100001234560000100040000000021", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000216 8 69180000010000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-        [Test]
-        public void Banco104_Caixa_SIG14_DV9()
-        {
-            var boleto = new Boleto
-            {
-                DataVencimento = new DateTime(2016, 10, 14),
-                ValorTitulo = (decimal)200,
-                NossoNumero = "3",
-                NumeroDocumento = "BO123456C",
-                EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = banco,
-                Sacado = Utils.GerarSacado()
-            };
-            boleto.ValidarDados();
-            Assert.AreEqual("9", boleto.CodigoBarra.DigitoVerificador, "Dígito Verificador diferente de 9");
-            Assert.AreEqual("14000000000000003-0", boleto.NossoNumeroFormatado, "Nosso número inválido");
-            Assert.AreEqual("10499694700000200001234560000100040000000030", boleto.CodigoBarra.CodigoDeBarras, "Código de Barra inválido");
-            Assert.AreEqual("10491.23456 60000.100044 00000.000307 9 69470000020000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
-        }
-
-
     }
 }

--- a/Boleto2.Net.Testes/CaixaEconomicaFederal_SIG14.cs
+++ b/Boleto2.Net.Testes/CaixaEconomicaFederal_SIG14.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Banco104_Caixa_SIG14
     {
         Banco banco;
@@ -27,13 +26,13 @@ namespace Boleto2Net.Testes
             banco.FormataCedente();
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_REM240()
         {
             Utils.TestarArquivoRemessa(banco, TipoArquivo.CNAB240, nameof(Banco104_Caixa_SIG14));
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_PDF()
         {
             Utils.TestarBoletoPDF(banco, nameof(Banco104_Caixa_SIG14));
@@ -41,7 +40,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV1()
         {
             var boleto = new Boleto
@@ -61,7 +60,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("10491.23456 60000.100044 00000.000646 1 70300000050000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV2()
         {
             var boleto = new Boleto
@@ -81,7 +80,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("10491.23456 60000.100044 00000.000489 2 69740000030000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV3()
         {
             var boleto = new Boleto
@@ -101,7 +100,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("10491.23456 60000.100044 00000.000562 3 70020000040900", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV4()
         {
             var boleto = new Boleto
@@ -121,7 +120,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("10491.23456 60000.100044 00000.000562 4 70020000040000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV5()
         {
             var boleto = new Boleto
@@ -142,7 +141,7 @@ namespace Boleto2Net.Testes
         }
 
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV6()
         {
             var boleto = new Boleto
@@ -164,7 +163,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV7()
         {
             var boleto = new Boleto
@@ -186,7 +185,7 @@ namespace Boleto2Net.Testes
 
 
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV8()
         {
             var boleto = new Boleto
@@ -206,7 +205,7 @@ namespace Boleto2Net.Testes
             Assert.AreEqual("10491.23456 60000.100044 00000.000216 8 69180000010000", boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
 
-        [TestMethod]
+        [Test]
         public void Banco104_Caixa_SIG14_DV9()
         {
             var boleto = new Boleto

--- a/Boleto2.Net.Testes/ExemploClasseProxy.cs
+++ b/Boleto2.Net.Testes/ExemploClasseProxy.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Boleto2Net_ExemploClasseProxy
+    public class Boleto2NetExemploClasseProxy
     {
         [Test]
         public void Boleto2Net_ExemploProxy()

--- a/Boleto2.Net.Testes/ExemploClasseProxy.cs
+++ b/Boleto2.Net.Testes/ExemploClasseProxy.cs
@@ -1,13 +1,12 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.IO;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Boleto2Net_ExemploClasseProxy
     {
-        [TestMethod]
+        [Test]
         public void Boleto2Net_ExemploProxy()
         {
             var mensagemErro = "";

--- a/Boleto2.Net.Testes/FatorVencimento.cs
+++ b/Boleto2.Net.Testes/FatorVencimento.cs
@@ -1,19 +1,24 @@
 ﻿using System;
+using Boleto2Net.Extensions;
 using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    public class Boleto2Net_FatorVencimento
+    public class DateTimeExtensionsTest
     {
         [Test]
-        public void Boleto2Net_FatorVencimentos()
+        public void GeracaoCorretaDeFatorVencimento()
         {
-            Assert.AreEqual(1000, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 22, 0, 0, 0) }));
-            Assert.AreEqual(1001, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 23, 0, 0, 0) }));
-            Assert.AreEqual(5947, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2014, 01, 18, 0, 0, 0) }));
-            Assert.AreEqual(6000, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2014, 03, 12, 0, 0, 0) }));
-            Assert.AreEqual(7046, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2017, 01, 21, 0, 0, 0) }));
-            Assert.AreEqual(9999, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 21, 0, 0, 0) }));
+            var inicio = new DateTime(2010, 01, 31, 0, 0, 0);
+            var fim = new DateTime(2025, 02, 21, 0, 0, 0);
+            var totalDays = (fim - inicio).TotalDays;
+            for (int i = 0; i < totalDays; i++)
+            {
+                var dateTime = inicio.AddDays(i);
+                Assert.AreEqual(4499 + i, dateTime.FatorVencimento());
+            }
+            Assert.AreEqual(1000, fim.AddDays(1).FatorVencimento());
+            Assert.AreEqual(1001, fim.AddDays(2).FatorVencimento());
         }
     }
 }

--- a/Boleto2.Net.Testes/FatorVencimento.cs
+++ b/Boleto2.Net.Testes/FatorVencimento.cs
@@ -8,12 +8,12 @@ namespace Boleto2Net.Testes
         [Test]
         public void Boleto2Net_FatorVencimentos()
         {
-            Assert.AreEqual(1000, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2025, 02, 22, 0, 0, 0) }));
-            Assert.AreEqual(1001, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2025, 02, 23, 0, 0, 0) }));
-            Assert.AreEqual(5947, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2014, 01, 18, 0, 0, 0) } ));
-            Assert.AreEqual(6000, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2014, 03, 12, 0, 0, 0) }));
-            Assert.AreEqual(7046, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2017, 01, 21, 0, 0, 0) }));
-            Assert.AreEqual(9999, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2025, 02, 21, 0, 0, 0) }));
+            Assert.AreEqual(1000, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 22, 0, 0, 0) }));
+            Assert.AreEqual(1001, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 23, 0, 0, 0) }));
+            Assert.AreEqual(5947, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2014, 01, 18, 0, 0, 0) }));
+            Assert.AreEqual(6000, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2014, 03, 12, 0, 0, 0) }));
+            Assert.AreEqual(7046, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2017, 01, 21, 0, 0, 0) }));
+            Assert.AreEqual(9999, AbstractBanco.FatorVencimento(new Boleto { DataVencimento = new DateTime(2025, 02, 21, 0, 0, 0) }));
         }
     }
 }

--- a/Boleto2.Net.Testes/FatorVencimento.cs
+++ b/Boleto2.Net.Testes/FatorVencimento.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    [TestClass]
     public class Boleto2Net_FatorVencimento
     {
-        [TestMethod]
+        [Test]
         public void Boleto2Net_FatorVencimentos()
         {
             Assert.AreEqual(1000, AbstractBanco.FatorVencimento(new Boleto2Net.Boleto { DataVencimento = new DateTime(2025, 02, 22, 0, 0, 0) }));

--- a/Boleto2.Net.Testes/Properties/AssemblyInfo.cs
+++ b/Boleto2.Net.Testes/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -168,7 +168,7 @@ namespace Boleto2Net.Testes
                 {
                     using (BoletoBancario imprimeBoleto = new BoletoBancario
                     {
-                        boleto = boletoTmp,
+                        Boleto = boletoTmp,
                         OcultarInstrucoes = false,
                         MostrarComprovanteEntrega = false,
                         MostrarEnderecoCedente = true,

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using NReco.PdfGenerator;
 using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {
-    sealed class Utils
+    internal sealed class Utils
     {
+        private static int _contador = 1;
+
+        private static int _proximoNossoNumero = 1;
 
         internal static Cedente GerarCedente(string codigoCedente, string digitoCodigoCedente, ContaBancaria contaBancaria)
         {
@@ -30,11 +34,9 @@ namespace Boleto2Net.Testes
             };
         }
 
-        static int _contador = 1;
         internal static Sacado GerarSacado()
         {
             if (_contador % 2 == 0)
-            {
                 return new Sacado
                 {
                     CPFCNPJ = "123.456.789-09",
@@ -50,40 +52,34 @@ namespace Boleto2Net.Testes
                         CEP = "56789012"
                     }
                 };
-            }
-            else
+            return new Sacado
             {
-                return new Sacado
+                CPFCNPJ = "98.765.432/1098-74",
+                Nome = "Sacado Teste PJ",
+                Observacoes = "Matricula 123/4",
+                Endereco = new Endereco
                 {
-                    CPFCNPJ = "98.765.432/1098-74",
-                    Nome = "Sacado Teste PJ",
-                    Observacoes = "Matricula 123/4",
-                    Endereco = new Endereco
-                    {
-                        LogradouroEndereco = "Avenida Testando",
-                        LogradouroNumero = "123",
-                        Bairro = "Bairro",
-                        Cidade = "Cidade",
-                        UF = "SP",
-                        CEP = "12345678"
-                    }
-                };
-            }
+                    LogradouroEndereco = "Avenida Testando",
+                    LogradouroNumero = "123",
+                    Bairro = "Bairro",
+                    Cidade = "Cidade",
+                    UF = "SP",
+                    CEP = "12345678"
+                }
+            };
         }
 
-        static int _proximoNossoNumero = 1;
         internal static Boletos GerarBoletos(Banco banco, int quantidadeBoletos)
         {
             var boletos = new Boletos
             {
                 Banco = banco
             };
-            for (int i = 1; i <= quantidadeBoletos; i++)
-            {
+            for (var i = 1; i <= quantidadeBoletos; i++)
                 boletos.Add(GerarBoleto(banco, i));
-            }
             return boletos;
         }
+
         internal static Boleto GerarBoleto(Banco banco, int i)
         {
             var boleto = new Boleto
@@ -97,7 +93,7 @@ namespace Boleto2Net.Testes
                 NossoNumero = (223344 + _proximoNossoNumero).ToString(),
                 NumeroDocumento = "BB" + _proximoNossoNumero.ToString("D6") + (char)(64 + i),
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Aceite = (_contador % 2) == 0 ? "N" : "A",
+                Aceite = _contador % 2 == 0 ? "N" : "A",
                 CodigoInstrucao1 = "11",
                 CodigoInstrucao2 = "22",
                 DataDesconto = DateTime.Now.AddMonths(i),
@@ -110,7 +106,7 @@ namespace Boleto2Net.Testes
                 ValorJurosDia = (decimal)(100 * i * 0.002),
                 MensagemArquivoRemessa = "Mensagem para o arquivo remessa",
                 MensagemInstrucoesCaixa = "Mensagem para instruções do caixa",
-                NumeroControleParticipante = "CHAVEPRIMARIA=" + _proximoNossoNumero.ToString()
+                NumeroControleParticipante = "CHAVEPRIMARIA=" + _proximoNossoNumero
             };
             // Avalista
             if (_contador % 3 == 0)
@@ -120,17 +116,17 @@ namespace Boleto2Net.Testes
             }
             // Grupo Demonstrativo do Boleto
             var grupoDemonstrativo = new GrupoDemonstrativo { Descricao = "GRUPO 1" };
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 1", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.15 });
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 2", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.05 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 1", Referencia = boleto.DataEmissao.AddMonths(-1).Month + "/" + boleto.DataEmissao.AddMonths(-1).Year, Valor = boleto.ValorTitulo * (decimal)0.15 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 2", Referencia = boleto.DataEmissao.AddMonths(-1).Month + "/" + boleto.DataEmissao.AddMonths(-1).Year, Valor = boleto.ValorTitulo * (decimal)0.05 });
             boleto.Demonstrativos.Add(grupoDemonstrativo);
             grupoDemonstrativo = new GrupoDemonstrativo { Descricao = "GRUPO 2" };
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 2, Item 1", Referencia = (boleto.DataEmissao.Month).ToString() + "/" + (boleto.DataEmissao.Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.20 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 2, Item 1", Referencia = boleto.DataEmissao.Month + "/" + boleto.DataEmissao.Year, Valor = boleto.ValorTitulo * (decimal)0.20 });
             boleto.Demonstrativos.Add(grupoDemonstrativo);
             grupoDemonstrativo = new GrupoDemonstrativo { Descricao = "GRUPO 3" };
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 1", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.37 });
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 2", Referencia = (boleto.DataEmissao.Month).ToString() + "/" + (boleto.DataEmissao.Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.03 });
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 3", Referencia = (boleto.DataEmissao.Month).ToString() + "/" + (boleto.DataEmissao.Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.12 });
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 4", Referencia = (boleto.DataEmissao.AddMonths(+1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(+1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.08 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 1", Referencia = boleto.DataEmissao.AddMonths(-1).Month + "/" + boleto.DataEmissao.AddMonths(-1).Year, Valor = boleto.ValorTitulo * (decimal)0.37 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 2", Referencia = boleto.DataEmissao.Month + "/" + boleto.DataEmissao.Year, Valor = boleto.ValorTitulo * (decimal)0.03 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 3", Referencia = boleto.DataEmissao.Month + "/" + boleto.DataEmissao.Year, Valor = boleto.ValorTitulo * (decimal)0.12 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 4", Referencia = boleto.DataEmissao.AddMonths(+1).Month + "/" + boleto.DataEmissao.AddMonths(+1).Year, Valor = boleto.ValorTitulo * (decimal)0.08 });
             boleto.Demonstrativos.Add(grupoDemonstrativo);
 
             boleto.ValidarDados();
@@ -141,9 +137,9 @@ namespace Boleto2Net.Testes
 
         internal static void TestarBoletoPDF(Banco banco, string nomeCarteira)
         {
-            int quantidadeBoletosParaTeste = 3;
+            var quantidadeBoletosParaTeste = 3;
             var boletos = GerarBoletos(banco, quantidadeBoletosParaTeste);
-            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste.ToString());
+            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste);
 
             // Define o nome do arquivo.
             var nomeArquivo = Path.GetTempPath() + "Boleto2Net\\" + nomeCarteira + "_Arquivo.PDF";
@@ -164,9 +160,9 @@ namespace Boleto2Net.Testes
             try
             {
                 var html = new StringBuilder();
-                foreach (Boleto boletoTmp in boletos)
+                foreach (var boletoTmp in boletos)
                 {
-                    using (BoletoBancario imprimeBoleto = new BoletoBancario
+                    using (var boletoParaImpressao = new BoletoBancario
                     {
                         Boleto = boletoTmp,
                         OcultarInstrucoes = false,
@@ -176,15 +172,12 @@ namespace Boleto2Net.Testes
                     })
                     {
                         html.Append("<div style=\"page-break-after: always;\">");
-                        html.Append(imprimeBoleto.MontaHtml());
+                        html.Append(boletoParaImpressao.MontaHtml());
                         html.Append("</div>");
                     }
-                    var pdf = new NReco.PdfGenerator.HtmlToPdfConverter().GeneratePdf(html.ToString());
-                    using (FileStream fs = new FileStream(nomeArquivo, FileMode.Create))
-                    {
+                    var pdf = new HtmlToPdfConverter().GeneratePdf(html.ToString());
+                    using (var fs = new FileStream(nomeArquivo, FileMode.Create))
                         fs.Write(pdf, 0, pdf.Length);
-                        fs.Close();
-                    }
                 }
             }
             catch (Exception e)
@@ -200,33 +193,27 @@ namespace Boleto2Net.Testes
 
         internal static void TestarArquivoRemessa(Banco banco, TipoArquivo tipoArquivo, string nomeCarteira)
         {
-            int quantidadeBoletosParaTeste = 36;
+            const int quantidadeBoletosParaTeste = 36;
             var boletos = GerarBoletos(banco, quantidadeBoletosParaTeste);
-            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste.ToString());
+            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste);
 
             // Define o nome do arquivo.
-            var nomeArquivo = Path.GetTempPath() + "Boleto2Net\\" + nomeCarteira + "_Arquivo" + tipoArquivo.ToString() + ".REM";
+            var nomeArquivo = Path.Combine(Path.GetTempPath(), "Boleto2Net", $"{nomeCarteira}_Arquivo{tipoArquivo}.REM");
 
             // Cria pasta para os arquivos
-            if (Directory.Exists(Path.GetDirectoryName(nomeArquivo)) == false)
+            if (!Directory.Exists(Path.GetDirectoryName(nomeArquivo)))
                 Directory.CreateDirectory(Path.GetDirectoryName(nomeArquivo));
 
-            // Se o arquivo já existir (testes anteriores), apaga o arquivo.
+            File.Delete(nomeArquivo);
             if (File.Exists(nomeArquivo))
-            {
-                File.Delete(nomeArquivo);
-                if (File.Exists(nomeArquivo))
-                    Assert.Fail("Arquivo Remessa não foi excluído: " + nomeArquivo);
-            }
+                Assert.Fail("Arquivo Remessa não foi excluído: " + nomeArquivo);
 
             // Gera o arquivo remessa.
             try
             {
                 var arquivoRemessa = new ArquivoRemessa(boletos.Banco, tipoArquivo, 1);
                 using (var fileStream = new FileStream(nomeArquivo, FileMode.Create))
-                {
                     arquivoRemessa.GerarArquivoRemessa(boletos, fileStream);
-                }
             }
             catch (Exception e)
             {
@@ -238,6 +225,5 @@ namespace Boleto2Net.Testes
             // Se o arquivo existir, considera o teste OK
             Assert.IsTrue(File.Exists(nomeArquivo), "Arquivo Remessa não encontrado: " + nomeArquivo);
         }
-
     }
-};
+}

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -89,12 +89,12 @@ namespace Boleto2Net.Testes
             var boleto = new Boleto
             {
                 Banco = banco,
-                Sacado = Utils.GerarSacado(),
+                Sacado = GerarSacado(),
                 DataEmissao = DateTime.Now.AddDays(-3),
                 DataProcessamento = DateTime.Now,
                 DataVencimento = DateTime.Now.AddMonths(i),
                 ValorTitulo = (decimal)100 * i,
-                NossoNumero = (223344+proximoNossoNumero).ToString(),
+                NossoNumero = (223344 + proximoNossoNumero).ToString(),
                 NumeroDocumento = "BB" + proximoNossoNumero.ToString("D6") + (char)(64 + i),
                 EspecieDocumento = TipoEspecieDocumento.DM,
                 Aceite = (contador % 2) == 0 ? "N" : "A",
@@ -110,7 +110,7 @@ namespace Boleto2Net.Testes
                 ValorJurosDia = (decimal)(100 * i * 0.002),
                 MensagemArquivoRemessa = "Mensagem para o arquivo remessa",
                 MensagemInstrucoesCaixa = "Mensagem para instruções do caixa",
-                NumeroControleParticipante = "CHAVEPRIMARIA="+ proximoNossoNumero.ToString()
+                NumeroControleParticipante = "CHAVEPRIMARIA=" + proximoNossoNumero.ToString()
             };
             // Avalista
             if (contador % 3 == 0)
@@ -120,7 +120,7 @@ namespace Boleto2Net.Testes
             }
             // Grupo Demonstrativo do Boleto
             var grupoDemonstrativo = new GrupoDemonstrativo { Descricao = "GRUPO 1" };
-            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 1", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString()+"/"+(boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo*(decimal)0.15 });
+            grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 1", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.15 });
             grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 1, Item 2", Referencia = (boleto.DataEmissao.AddMonths(-1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(-1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.05 });
             boleto.Demonstrativos.Add(grupoDemonstrativo);
             grupoDemonstrativo = new GrupoDemonstrativo { Descricao = "GRUPO 2" };
@@ -132,7 +132,7 @@ namespace Boleto2Net.Testes
             grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 3", Referencia = (boleto.DataEmissao.Month).ToString() + "/" + (boleto.DataEmissao.Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.12 });
             grupoDemonstrativo.Itens.Add(new ItemDemonstrativo { Descricao = "Grupo 3, Item 4", Referencia = (boleto.DataEmissao.AddMonths(+1).Month).ToString() + "/" + (boleto.DataEmissao.AddMonths(+1).Year).ToString(), Valor = boleto.ValorTitulo * (decimal)0.08 });
             boleto.Demonstrativos.Add(grupoDemonstrativo);
-                
+
             boleto.ValidarDados();
             contador++;
             proximoNossoNumero++;
@@ -143,7 +143,7 @@ namespace Boleto2Net.Testes
         {
             int quantidadeBoletosParaTeste = 3;
             var boletos = GerarBoletos(banco, quantidadeBoletosParaTeste);
-            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de "+ quantidadeBoletosParaTeste.ToString());
+            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste.ToString());
 
             // Define o nome do arquivo.
             var nomeArquivo = Path.GetTempPath() + "Boleto2Net\\" + nomeCarteira + "_Arquivo.PDF";
@@ -187,7 +187,7 @@ namespace Boleto2Net.Testes
                     }
                 }
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 if (File.Exists(nomeArquivo))
                     File.Delete(nomeArquivo);
@@ -202,7 +202,7 @@ namespace Boleto2Net.Testes
         {
             int quantidadeBoletosParaTeste = 36;
             var boletos = GerarBoletos(banco, quantidadeBoletosParaTeste);
-            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de "+ quantidadeBoletosParaTeste.ToString());
+            Assert.AreEqual(quantidadeBoletosParaTeste, boletos.Count, "Quantidade de boletos diferente de " + quantidadeBoletosParaTeste.ToString());
 
             // Define o nome do arquivo.
             var nomeArquivo = Path.GetTempPath() + "Boleto2Net\\" + nomeCarteira + "_Arquivo" + tipoArquivo.ToString() + ".REM";
@@ -228,7 +228,7 @@ namespace Boleto2Net.Testes
                     arquivoRemessa.GerarArquivoRemessa(boletos, fileStream);
                 }
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 if (File.Exists(nomeArquivo))
                     File.Delete(nomeArquivo);

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
+using NUnit.Framework;
 
 namespace Boleto2Net.Testes
 {

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -30,10 +30,10 @@ namespace Boleto2Net.Testes
             };
         }
 
-        static int contador = 1;
+        static int _contador = 1;
         internal static Sacado GerarSacado()
         {
-            if (contador % 2 == 0)
+            if (_contador % 2 == 0)
             {
                 return new Sacado
                 {
@@ -71,7 +71,7 @@ namespace Boleto2Net.Testes
             }
         }
 
-        static int proximoNossoNumero = 1;
+        static int _proximoNossoNumero = 1;
         internal static Boletos GerarBoletos(Banco banco, int quantidadeBoletos)
         {
             var boletos = new Boletos
@@ -94,10 +94,10 @@ namespace Boleto2Net.Testes
                 DataProcessamento = DateTime.Now,
                 DataVencimento = DateTime.Now.AddMonths(i),
                 ValorTitulo = (decimal)100 * i,
-                NossoNumero = (223344 + proximoNossoNumero).ToString(),
-                NumeroDocumento = "BB" + proximoNossoNumero.ToString("D6") + (char)(64 + i),
+                NossoNumero = (223344 + _proximoNossoNumero).ToString(),
+                NumeroDocumento = "BB" + _proximoNossoNumero.ToString("D6") + (char)(64 + i),
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Aceite = (contador % 2) == 0 ? "N" : "A",
+                Aceite = (_contador % 2) == 0 ? "N" : "A",
                 CodigoInstrucao1 = "11",
                 CodigoInstrucao2 = "22",
                 DataDesconto = DateTime.Now.AddMonths(i),
@@ -110,10 +110,10 @@ namespace Boleto2Net.Testes
                 ValorJurosDia = (decimal)(100 * i * 0.002),
                 MensagemArquivoRemessa = "Mensagem para o arquivo remessa",
                 MensagemInstrucoesCaixa = "Mensagem para instruções do caixa",
-                NumeroControleParticipante = "CHAVEPRIMARIA=" + proximoNossoNumero.ToString()
+                NumeroControleParticipante = "CHAVEPRIMARIA=" + _proximoNossoNumero.ToString()
             };
             // Avalista
-            if (contador % 3 == 0)
+            if (_contador % 3 == 0)
             {
                 boleto.Avalista = GerarSacado();
                 boleto.Avalista.Nome = boleto.Avalista.Nome.Replace("Sacado", "Avalista");
@@ -134,8 +134,8 @@ namespace Boleto2Net.Testes
             boleto.Demonstrativos.Add(grupoDemonstrativo);
 
             boleto.ValidarDados();
-            contador++;
-            proximoNossoNumero++;
+            _contador++;
+            _proximoNossoNumero++;
             return boleto;
         }
 

--- a/Boleto2.Net.Testes/packages.config
+++ b/Boleto2.Net.Testes/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NReco.PdfGenerator" version="1.1.12.0" targetFramework="net40" />
+  <package id="NUnit" version="3.6.1" targetFramework="net40" />
 </packages>

--- a/Boleto2.Net.Testes/packages.config
+++ b/Boleto2.Net.Testes/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="NReco.PdfGenerator" version="1.1.12.0" targetFramework="net40" />
   <package id="NUnit" version="3.6.1" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net40" />
 </packages>

--- a/Boleto2.Net.v3.ncrunchsolution
+++ b/Boleto2.Net.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/Boleto2.Net/Banco/AbstractBanco.cs
+++ b/Boleto2.Net/Banco/AbstractBanco.cs
@@ -1,6 +1,6 @@
 using System;
-using Boleto2Net.Util;
 using System.Collections.Generic;
+using Boleto2Net.Extensions;
 
 namespace Boleto2Net
 {
@@ -52,7 +52,7 @@ namespace Boleto2Net
             {
                 boleto.CodigoBarra.CodigoBanco = Utils.FitStringLength(Codigo.ToString(), 3, 3, '0', 0, true, true, true);
                 boleto.CodigoBarra.Moeda = boleto.CodigoMoeda;
-                boleto.CodigoBarra.FatorVencimento = FatorVencimento(boleto);
+                boleto.CodigoBarra.FatorVencimento = boleto.DataVencimento.FatorVencimento();
                 boleto.CodigoBarra.ValorDocumento = boleto.ValorTitulo.ToString("N2").Replace(",", "").Replace(".", "").PadLeft(10, '0');
             }
         }
@@ -83,50 +83,50 @@ namespace Boleto2Net
             //BBBMC.CCCCD1 CCCCC.CCCCCD2 CCCCC.CCCCCD3 D4 FFFFVVVVVVVVVV
             #region Campo 1
             // POSIÇÃO 1 A 3 DO CODIGO DE BARRAS
-            string BBB = boleto.CodigoBarra.CodigoDeBarras.Substring(0, 3);
+            string bbb = boleto.CodigoBarra.CodigoDeBarras.Substring(0, 3);
             // POSIÇÃO 4 DO CODIGO DE BARRAS
-            string M = boleto.CodigoBarra.CodigoDeBarras.Substring(3, 1);
+            string m = boleto.CodigoBarra.CodigoDeBarras.Substring(3, 1);
             // POSIÇÃO 20 A 24 DO CODIGO DE BARRAS
-            string CCCCC = boleto.CodigoBarra.CodigoDeBarras.Substring(19, 5);
+            string ccccc = boleto.CodigoBarra.CodigoDeBarras.Substring(19, 5);
             // Calculo do Dígito
-            string D1 = CalcularDVModulo10(BBB + M + CCCCC).ToString();
+            string d1 = CalcularDvModulo10(bbb + m + ccccc).ToString();
             // Formata Grupo 1
-            string Grupo1 = string.Format("{0}{1}{2}.{3}{4} ", BBB, M, CCCCC.Substring(0, 1), CCCCC.Substring(1, 4), D1);
+            string grupo1 = string.Format("{0}{1}{2}.{3}{4} ", bbb, m, ccccc.Substring(0, 1), ccccc.Substring(1, 4), d1);
             #endregion Campo 1
 
             #region Campo 2
             //POSIÇÃO 25 A 34 DO COD DE BARRAS
-            string D2A = boleto.CodigoBarra.CodigoDeBarras.Substring(24, 10);
+            string d2A = boleto.CodigoBarra.CodigoDeBarras.Substring(24, 10);
             // Calculo do Dígito
-            string D2B = CalcularDVModulo10(D2A).ToString();
+            string d2B = CalcularDvModulo10(d2A).ToString();
             // Formata Grupo 2
-            string Grupo2 = string.Format("{0}.{1}{2} ", D2A.Substring(0, 5), D2A.Substring(5, 5), D2B);
+            string grupo2 = string.Format("{0}.{1}{2} ", d2A.Substring(0, 5), d2A.Substring(5, 5), d2B);
             #endregion Campo 2
 
             #region Campo 3
             //POSIÇÃO 35 A 44 DO CODIGO DE BARRAS
-            string D3A = boleto.CodigoBarra.CodigoDeBarras.Substring(34, 10);
+            string d3A = boleto.CodigoBarra.CodigoDeBarras.Substring(34, 10);
             // Calculo do Dígito
-            string D3B = CalcularDVModulo10(D3A).ToString();
+            string d3B = CalcularDvModulo10(d3A).ToString();
             // Formata Grupo 3
-            string Grupo3 = string.Format("{0}.{1}{2} ", D3A.Substring(0, 5), D3A.Substring(5, 5), D3B);
+            string grupo3 = string.Format("{0}.{1}{2} ", d3A.Substring(0, 5), d3A.Substring(5, 5), d3B);
             #endregion Campo 3
 
             #region Campo 4
             // Dígito Verificador do Código de Barras
-            string Grupo4 = string.Format("{0} ", boleto.CodigoBarra.DigitoVerificador);
+            string grupo4 = string.Format("{0} ", boleto.CodigoBarra.DigitoVerificador);
             #endregion Campo 4
 
             #region Campo 5
             //POSICAO 6 A 9 DO CODIGO DE BARRAS
-            string D5A = boleto.CodigoBarra.CodigoDeBarras.Substring(5, 4);
+            string d5A = boleto.CodigoBarra.CodigoDeBarras.Substring(5, 4);
             //POSICAO 10 A 19 DO CODIGO DE BARRAS
-            string D5B = boleto.CodigoBarra.CodigoDeBarras.Substring(9, 10);
+            string d5B = boleto.CodigoBarra.CodigoDeBarras.Substring(9, 10);
             // Formata Grupo 5
-            string Grupo5 = string.Format("{0}{1}", D5A, D5B);
+            string grupo5 = string.Format("{0}{1}", d5A, d5B);
             #endregion Campo 5
 
-            boleto.CodigoBarra.LinhaDigitavel = Grupo1 + Grupo2 + Grupo3 + Grupo4 + Grupo5;
+            boleto.CodigoBarra.LinhaDigitavel = grupo1 + grupo2 + grupo3 + grupo4 + grupo5;
 
         }
 
@@ -210,46 +210,7 @@ namespace Boleto2Net
             throw new NotImplementedException("LerTrailerRetornoCNAB400 - Função não implementada na classe filha. Implemente na classe que está sendo criada.");
         }
 
-        /// <summary>
-        /// Fator de vencimento do boleto.
-        /// </summary>
-        /// <param name="boleto"></param>
-        /// <returns>Retorno Fator de Vencimento</returns>
-        /// <remarks>
-        ///     Wellington(wcarvalho@novatela.com.br) 
-        ///     Com base na proposta feita pela CENEGESC de acordo com o comunicado FEBRABAN de n° 082/2012 de 14/06/2012 segue regra para implantação.
-        ///     No dia 21/02/2025 o fator vencimento chegará em 9999 assim atigindo o tempo de utilização, para contornar esse problema foi definido com uma nova regra
-        ///     de utilizaçao criando um range de uso o range funcionara controlando a emissão dos boletos.
-        ///     Exemplo:
-        ///         Data Atual: 12/03/2014 = 6000
-        ///         Para os boletos vencidos, anterior a data atual é de 3000 fatores cerca de =/- 8 anos. Os boletos que forem gerados acima dos 3000 não serão aceitos pelas instituições financeiras.
-        ///         Para os boletos a vencer, posterior a data atual é de 5500 fatores cerca de +/- 15 anos. Os boletos que forem gerados acima dos 5500 não serão aceitos pelas instituições financeiras.
-        ///     Quando o fator de vencimento atingir 9999 ele retorna para 1000
-        ///     Exemplo:
-        ///         21/02/2025 = 9999
-        ///         22/02/2025 = 1000
-        ///         23/02/2025 = 1001
-        ///         ...
-        ///         05/03/2025 = 1011
-        /// </remarks>
-        public static long FatorVencimento(Boleto boleto)
-        {
-            var dateBase = new DateTime(1997, 10, 7, 0, 0, 0);
-
-            // Verifica se a data esta dentro do range utilizavel
-            var dataAtual = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
-            long rangeUtilizavel = Utils.DateDiff(DateInterval.Day, dataAtual, boleto.DataVencimento);
-
-            if (rangeUtilizavel > 5500 || rangeUtilizavel < -3000)
-                throw new Exception("Data do vencimento fora do range de utilização proposto pela CENEGESC. Comunicado FEBRABAN de n° 082/2012 de 14/06/2012");
-
-            while (boleto.DataVencimento > dateBase.AddDays(9999))
-                dateBase = boleto.DataVencimento.AddDays(-(((Utils.DateDiff(DateInterval.Day, dateBase, boleto.DataVencimento) - 9999) - 1) + 1000));
-
-            return Utils.DateDiff(DateInterval.Day, dateBase, boleto.DataVencimento);
-        }
-
-        private int CalcularDVModulo10(string texto)
+        private int CalcularDvModulo10(string texto)
         {
             int digito, soma = 0, peso = 2, resto;
             for (int i = texto.Length; i > 0; i--)

--- a/Boleto2.Net/Banco/Banco.cs
+++ b/Boleto2.Net/Banco/Banco.cs
@@ -7,7 +7,7 @@ namespace Boleto2Net
 {
     public class Banco : AbstractBanco
     {
-        private IBanco _IBanco;
+        private readonly IBanco _banco;
 
         public Banco(int codigoBanco)
         {
@@ -16,16 +16,16 @@ namespace Boleto2Net
                 switch (codigoBanco)
                 {
                     case 001:
-                        _IBanco = new Banco_Brasil();
+                        _banco = new BancoBrasil();
                         break;
                     case 104:
-                        _IBanco = new Banco_Caixa();
+                        _banco = new BancoCaixa();
                         break;
                     case 237:
-                        _IBanco = new Banco_Bradesco();
+                        _banco = new BancoBradesco();
                         break;
                     case 756:
-                        _IBanco = new Banco_Sicoob();
+                        _banco = new BancoSicoob();
                         break;
                     default:
                         throw new Exception("Banco não implementando: " + codigoBanco);
@@ -41,30 +41,21 @@ namespace Boleto2Net
 
         public override int Codigo
         {
-            get { return _IBanco.Codigo; }
-            set { _IBanco.Codigo = value; }
+            get { return _banco.Codigo; }
+            set { _banco.Codigo = value; }
         }
-        public override string Digito
-        {
-            get { return _IBanco.Digito; }
-        }
-        public override string Nome
-        {
-            get { return _IBanco.Nome; }
-        }
-        public override bool RemoveAcentosArquivoRemessa
-        {
-            get { return _IBanco.RemoveAcentosArquivoRemessa; }
-        }
+        public override string Digito => _banco.Digito;
+
+        public override string Nome => _banco.Nome;
+
+        public override bool RemoveAcentosArquivoRemessa => _banco.RemoveAcentosArquivoRemessa;
+
         public override Cedente Cedente
         {
-            get { return _IBanco.Cedente; }
-            set { _IBanco.Cedente = value; }
+            get { return _banco.Cedente; }
+            set { _banco.Cedente = value; }
         }
-        public override List<string> IdsRetornoCnab400RegistroDetalhe
-        {
-            get { return _IBanco.IdsRetornoCnab400RegistroDetalhe; }
-        }
+        public override List<string> IdsRetornoCnab400RegistroDetalhe => _banco.IdsRetornoCnab400RegistroDetalhe;
 
         #endregion
 
@@ -72,7 +63,7 @@ namespace Boleto2Net
         {
             try
             {
-                _IBanco.FormataCedente();
+                _banco.FormataCedente();
             }
             catch (Exception ex)
             {
@@ -83,7 +74,7 @@ namespace Boleto2Net
         {
             try
             {
-                return _IBanco.FormataCodigoBarraCampoLivre(boleto);
+                return _banco.FormataCodigoBarraCampoLivre(boleto);
             }
             catch (Exception ex)
             {
@@ -94,7 +85,7 @@ namespace Boleto2Net
         {
             try
             {
-                _IBanco.FormataNossoNumero(boleto);
+                _banco.FormataNossoNumero(boleto);
             }
             catch (Exception ex)
             {
@@ -106,7 +97,7 @@ namespace Boleto2Net
             try
             {
                 // Valida os dados do Boleto na classe do banco responsável
-                _IBanco.ValidaBoleto(boleto);
+                _banco.ValidaBoleto(boleto);
                 // Formata nosso número (Classe Abstrata)
                 FormataNossoNumero(boleto);
                 // Formata o código de Barras (Classe Abstrata)
@@ -125,7 +116,7 @@ namespace Boleto2Net
         {
             try
             {
-                return _IBanco.GerarHeaderRemessa(tipoArquivo, numeroArquivoRemessa, ref numeroRegistroGeral);
+                return _banco.GerarHeaderRemessa(tipoArquivo, numeroArquivoRemessa, ref numeroRegistroGeral);
             }
             catch (Exception ex)
             {
@@ -136,7 +127,7 @@ namespace Boleto2Net
         {
             try
             {
-                return _IBanco.GerarDetalheRemessa(tipoArquivo, boleto, ref numeroRegistro);
+                return _banco.GerarDetalheRemessa(tipoArquivo, boleto, ref numeroRegistro);
             }
             catch (Exception ex)
             {
@@ -152,7 +143,7 @@ namespace Boleto2Net
         {
             try
             {
-                return _IBanco.GerarTrailerRemessa(tipoArquivo, numeroArquivoRemessa,
+                return _banco.GerarTrailerRemessa(tipoArquivo, numeroArquivoRemessa,
                                             ref numeroRegistroGeral, valorBoletoGeral,
                                             numeroRegistroCobrancaSimples, valorCobrancaSimples,
                                             numeroRegistroCobrancaVinculada, valorCobrancaVinculada,
@@ -170,27 +161,32 @@ namespace Boleto2Net
 
         public override void LerDetalheRetornoCNAB240SegmentoT(ref Boleto boleto, string registro)
         {
-            _IBanco.LerDetalheRetornoCNAB240SegmentoT(ref boleto, registro);
+            _banco.LerDetalheRetornoCNAB240SegmentoT(ref boleto, registro);
         }
+
         public override void LerDetalheRetornoCNAB240SegmentoU(ref Boleto boleto, string registro)
         {
-            _IBanco.LerDetalheRetornoCNAB240SegmentoU(ref boleto, registro);
+            _banco.LerDetalheRetornoCNAB240SegmentoU(ref boleto, registro);
         }
+
         public override void LerHeaderRetornoCNAB400(string registro)
         {
-            _IBanco.LerHeaderRetornoCNAB400(registro);
+            _banco.LerHeaderRetornoCNAB400(registro);
         }
+
         public override void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro)
         {
-            _IBanco.LerDetalheRetornoCNAB400Segmento1(ref boleto, registro);
+            _banco.LerDetalheRetornoCNAB400Segmento1(ref boleto, registro);
         }
+
         public override void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)
         {
-            _IBanco.LerDetalheRetornoCNAB400Segmento7(ref boleto, registro);
+            _banco.LerDetalheRetornoCNAB400Segmento7(ref boleto, registro);
         }
+
         public override void LerTrailerRetornoCNAB400(string registro)
         {
-            _IBanco.LerTrailerRetornoCNAB400(registro);
+            _banco.LerTrailerRetornoCNAB400(registro);
         }
 
         #endregion

--- a/Boleto2.Net/Banco/Banco_Bradesco.cs
+++ b/Boleto2.Net/Banco/Banco_Bradesco.cs
@@ -1,47 +1,47 @@
 using System;
 using System.Web.UI;
+using static System.String;
 
 [assembly: WebResource("BoletoNet.Imagens.237.jpg", "image/jpg")]
 
 namespace Boleto2Net
 {
-    internal class Banco_Bradesco : AbstractBanco
+    internal sealed class BancoBradesco : AbstractBanco
     {
-        internal Banco_Bradesco()
+        internal BancoBradesco()
         {
-            this.Codigo = 237;
-            this.Digito = "2";
-            this.Nome = "Bradesco";
-            this.IdsRetornoCnab400RegistroDetalhe.Add("1");
+            Codigo = 237;
+            Digito = "2";
+            Nome = "Bradesco";
+            IdsRetornoCnab400RegistroDetalhe.Add("1");
         }
 
         public override void FormataCedente()
         {
+            var contaBancaria = Cedente.ContaBancaria;
 
-            if (this.Cedente.ContaBancaria.Agencia.Length > 4)
-                throw new Exception("O número da agência (" + this.Cedente.ContaBancaria.Agencia + ") deve conter 4 dígitos.");
-            else if (this.Cedente.ContaBancaria.Agencia.Length < 4)
-                this.Cedente.ContaBancaria.Agencia = this.Cedente.ContaBancaria.Agencia.PadLeft(4, '0');
+            if (contaBancaria.Agencia.Length > 4)
+                throw new Exception($"O número da agência ({contaBancaria.Agencia}) deve conter 4 dígitos.");
+            if (contaBancaria.Agencia.Length < 4)
+                contaBancaria.Agencia = contaBancaria.Agencia.PadLeft(4, '0');
 
-            if (this.Cedente.ContaBancaria.Conta.Length > 7)
-                throw new Exception("O número da conta (" + this.Cedente.ContaBancaria.Conta + ") deve conter 7 dígitos.");
-            else if (this.Cedente.ContaBancaria.Conta.Length < 7)
-                this.Cedente.ContaBancaria.Conta = this.Cedente.ContaBancaria.Conta.PadLeft(7, '0');
+            if (contaBancaria.Conta.Length > 7)
+                throw new Exception($"O número da conta ({contaBancaria.Conta}) deve conter 7 dígitos.");
+            if (contaBancaria.Conta.Length < 7)
+                contaBancaria.Conta = contaBancaria.Conta.PadLeft(7, '0');
 
-            var codigoCedenteSemFormatacao = this.Cedente.Codigo;
+            if (Cedente.Codigo.Length > 20)
+                throw new Exception($"O código do Cedente ({Cedente.Codigo}) deve conter 20 dígitos.");
+            if (Cedente.Codigo.Length < 20)
+                Cedente.Codigo = Cedente.Codigo.PadLeft(20, '0');
 
-            if (this.Cedente.Codigo.Length > 20)
-                throw new Exception("O código do Cedente (" + this.Cedente.Codigo + ") deve conter 20 dígitos.");
-            else if (this.Cedente.Codigo.Length < 20)
-                this.Cedente.Codigo = this.Cedente.Codigo.PadLeft(20, '0');
+            Cedente.CodigoFormatado = $"{contaBancaria.Agencia}-{contaBancaria.DigitoAgencia}/{contaBancaria.Conta}-{contaBancaria.DigitoConta}";
 
-            this.Cedente.CodigoFormatado = String.Format("{0}-{1}/{2}-{3}", this.Cedente.ContaBancaria.Agencia, this.Cedente.ContaBancaria.DigitoAgencia, this.Cedente.ContaBancaria.Conta, this.Cedente.ContaBancaria.DigitoConta);
+            contaBancaria.LocalPagamento = "ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NO BRADESCO.";
 
-            this.Cedente.ContaBancaria.LocalPagamento = "ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NO BRADESCO.";
-
-            if (this.Cedente.ContaBancaria.CarteiraComVariacao != "09")
+            if (contaBancaria.CarteiraComVariacao != "09")
             {
-                throw new NotImplementedException("Carteira não implementada: " + this.Cedente.ContaBancaria.CarteiraComVariacao);
+                throw new NotImplementedException($"Carteira não implementada: {contaBancaria.CarteiraComVariacao}");
             }
 
         }
@@ -61,12 +61,12 @@ namespace Boleto2Net
                 throw new NotImplementedException("Não foi possível formatar o nosso número do boleto.");
             }
         }
-                private void FormataNossoNumero_09(Boleto boleto)
+        private void FormataNossoNumero_09(Boleto boleto)
         {
             // Carteira 09: Dúvida: Não sei se na carteira 09, o banco também emite o boleto. Se emitir, será necessário tirar a trava do nosso número em branco:
             // Se for só a empresa, devemos tratar aqui, que o nosso número não
             // O nosso número não pode ser em branco.
-            if (String.IsNullOrWhiteSpace(boleto.NossoNumero))
+            if (IsNullOrWhiteSpace(boleto.NossoNumero))
             {
                 throw new Exception("Nosso Número não informado.");
             }
@@ -74,17 +74,17 @@ namespace Boleto2Net
             {
                 // Nosso número não pode ter mais de 11 dígitos
                 if (boleto.NossoNumero.Length > 11)
-                    throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve conter 11 dígitos.");
+                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 11 dígitos.");
                 else
                     boleto.NossoNumero = boleto.NossoNumero.PadLeft(11, '0');
             }
             boleto.NossoNumeroDV = CalcularDV(boleto.Banco.Cedente.ContaBancaria.Carteira + boleto.NossoNumero);
-            boleto.NossoNumeroFormatado = string.Format("{0}/{1}-{2}", boleto.Banco.Cedente.ContaBancaria.Carteira, boleto.NossoNumero, boleto.NossoNumeroDV);
+            boleto.NossoNumeroFormatado = $"{boleto.Banco.Cedente.ContaBancaria.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
         }
 
         public override string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            string FormataCampoLivre = "";
+            var formataCampoLivre = "";
             if (boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao == "09")
             {
                 /// Campo Livre
@@ -93,35 +93,30 @@ namespace Boleto2Net
                 ///    26 a 36 - 11 - Número do Nosso Número(Sem o digito verificador)
                 ///    37 a 43 -  7 - Conta do Cedente (Sem o digito verificador,completar com zeros a esquerda quando necessário)
                 ///    44 a 44	- 1 - Zero            
-                FormataCampoLivre = string.Format("{0}{1}{2}{3}{4}",
-                                                    boleto.Banco.Cedente.ContaBancaria.Agencia,
-                                                    boleto.Banco.Cedente.ContaBancaria.Carteira,
-                                                    boleto.NossoNumero,
-                                                    boleto.Banco.Cedente.ContaBancaria.Conta,
-                                                    "0");
+                formataCampoLivre = $"{boleto.Banco.Cedente.ContaBancaria.Agencia}{boleto.Banco.Cedente.ContaBancaria.Carteira}{boleto.NossoNumero}{boleto.Banco.Cedente.ContaBancaria.Conta}{"0"}";
             }
             else
             {
                 throw new NotImplementedException("Não foi possível formatar o campo livre do código de barras do boleto.");
             }
-            return FormataCampoLivre;
+            return formataCampoLivre;
         }
 
         public override string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)
         {
             try
             {
-                string _header = String.Empty;
+                var header = Empty;
                 switch (tipoArquivo)
                 {
 
                     case TipoArquivo.CNAB400:
-                        _header += GerarHeaderRemessaCNAB400(numeroArquivoRemessa, ref numeroRegistroGeral);
+                        header += GerarHeaderRemessaCNAB400(numeroArquivoRemessa, ref numeroRegistroGeral);
                         break;
                     default:
                         throw new Exception("Tipo de arquivo inexistente.");
                 }
-                return _header;
+                return header;
             }
             catch (Exception ex)
             {
@@ -133,24 +128,23 @@ namespace Boleto2Net
         {
             try
             {
-                string _detalhe = String.Empty;
-                string _strline = String.Empty;
+                string detalhe = Empty, strline = Empty;
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB400:
-                        _detalhe += GerarDetalheRemessaCNAB400Registro1(boleto, ref numeroRegistro);
+                        detalhe += GerarDetalheRemessaCNAB400Registro1(boleto, ref numeroRegistro);
                         // Segmento R (Opcional)
-                        _strline = this.GerarDetalheRemessaCNAB400Registro2(boleto, ref numeroRegistro);
-                        if (!String.IsNullOrWhiteSpace(_strline))
+                        strline = GerarDetalheRemessaCNAB400Registro2(boleto, ref numeroRegistro);
+                        if (!IsNullOrWhiteSpace(strline))
                         {
-                            _detalhe += Environment.NewLine;
-                            _detalhe += _strline;
+                            detalhe += Environment.NewLine;
+                            detalhe += strline;
                         }
                         break;
                     default:
                         throw new Exception("Tipo de arquivo inexistente.");
                 }
-                return _detalhe;
+                return detalhe;
             }
             catch (Exception ex)
             {
@@ -159,24 +153,24 @@ namespace Boleto2Net
         }
 
         public override string GerarTrailerRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa,
-                                            ref int numeroRegistroGeral, decimal valorBoletoGeral,
-                                            int numeroRegistroCobrancaSimples, decimal valorCobrancaSimples,
-                                            int numeroRegistroCobrancaVinculada, decimal valorCobrancaVinculada,
-                                            int numeroRegistroCobrancaCaucionada, decimal valorCobrancaCaucionada,
-                                            int numeroRegistroCobrancaDescontada, decimal valorCobrancaDescontada)
+            ref int numeroRegistroGeral, decimal valorBoletoGeral,
+            int numeroRegistroCobrancaSimples, decimal valorCobrancaSimples,
+            int numeroRegistroCobrancaVinculada, decimal valorCobrancaVinculada,
+            int numeroRegistroCobrancaCaucionada, decimal valorCobrancaCaucionada,
+            int numeroRegistroCobrancaDescontada, decimal valorCobrancaDescontada)
         {
             try
             {
-                string _trailer = String.Empty;
+                var trailer = Empty;
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB400:
-                        _trailer = GerarTrailerRemessaCNAB400(ref numeroRegistroGeral);
+                        trailer = GerarTrailerRemessaCNAB400(ref numeroRegistroGeral);
                         break;
                     default:
                         throw new Exception("Tipo de arquivo inexistente.");
                 }
-                return _trailer;
+                return trailer;
             }
             catch (Exception ex)
             {
@@ -189,21 +183,21 @@ namespace Boleto2Net
             try
             {
                 numeroRegistroGeral++;
-                TRegistroEDI reg = new TRegistroEDI();
+                var reg = new TRegistroEDI();
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0002, 001, 0, "1", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0003, 007, 0, "REMESSA", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0010, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0012, 008, 0, "COBRANCA", ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 007, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0027, 020, 0, this.Cedente.Codigo.ToString(), '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0047, 030, 0, this.Cedente.Nome, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 007, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0027, 020, 0, Cedente.Codigo.ToString(), '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0047, 030, 0, Cedente.Nome, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0077, 018, 0, "237BRADESCO", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAA___________, 0095, 006, 0, DateTime.Now, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 008, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 008, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "MX", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0111, 007, 0, numeroArquivoRemessa, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0118, 277, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0118, 277, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
@@ -218,13 +212,13 @@ namespace Boleto2Net
             try
             {
                 numeroRegistroGeral++;
-                TRegistroEDI reg = new TRegistroEDI();
+                var reg = new TRegistroEDI();
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "1", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0002, 005, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0007, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0007, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 005, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0013, 007, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0021, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0022, 003, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0025, 005, 0, boleto.Banco.Cedente.ContaBancaria.Agencia, '0');
@@ -260,11 +254,11 @@ namespace Boleto2Net
                         break;
                 }
 
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0094, 001, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0095, 010, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0105, 001, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0106, 001, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0107, 002, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0094, 001, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0095, 010, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0105, 001, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0106, 001, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0107, 002, 0, Empty, ' ');
 
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "01", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NumeroDocumento, ' ');
@@ -292,12 +286,12 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 014, 0, boleto.Sacado.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0235, 040, 0, boleto.Sacado.Nome, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0275, 040, 0, boleto.Sacado.Endereco.FormataLogradouro(40), ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0315, 012, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0315, 012, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0327, 008, 0, boleto.Sacado.Endereco.CEP.Replace("-", ""), '0');
-                if (string.IsNullOrEmpty(boleto.Avalista.Nome))
+                if (IsNullOrEmpty(boleto.Avalista.Nome))
                 {
                     // Não tem avalista.
-                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0335, 060, 0, string.Empty, ' ');
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0335, 060, 0, Empty, ' ');
                 }
                 else if (boleto.Avalista.TipoCPFCNPJ("A") == "F")
                 {
@@ -305,14 +299,14 @@ namespace Boleto2Net
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0335, 009, 0, boleto.Avalista.CPFCNPJ.Substring(0, 9), '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0344, 004, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0348, 002, 0, boleto.Avalista.CPFCNPJ.Substring(9, 2), '0');
-                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, string.Empty, ' ');
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, Empty, ' ');
                     reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0352, 043, 0, boleto.Avalista.Nome, ' ');
                 }
                 else
                 {
                     // Avalista Pessoa Juridica
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0335, 015, 0, boleto.Avalista.CPFCNPJ, '0');
-                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, string.Empty, ' ');
+                    reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, Empty, ' ');
                     reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0352, 043, 0, boleto.Avalista.Nome, '0');
                 }
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
@@ -329,18 +323,18 @@ namespace Boleto2Net
         {
             try
             {
-                if (String.IsNullOrWhiteSpace(boleto.MensagemArquivoRemessa))
+                if (IsNullOrWhiteSpace(boleto.MensagemArquivoRemessa))
                     return "";
 
                 numeroRegistroGeral++;
-                TRegistroEDI reg = new TRegistroEDI();
+                var reg = new TRegistroEDI();
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "2", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 320, 0, boleto.MensagemArquivoRemessa, ' '); // 4 campos de 80 caracteres cada.
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0322, 006, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0328, 013, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0341, 006, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0347, 013, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0360, 007, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0360, 007, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0367, 003, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0370, 005, 0, boleto.Banco.Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0375, 007, 0, boleto.Banco.Cedente.ContaBancaria.Conta, '0');
@@ -361,9 +355,9 @@ namespace Boleto2Net
             try
             {
                 numeroRegistroGeral++;
-                TRegistroEDI reg = new TRegistroEDI();
+                var reg = new TRegistroEDI();
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "9", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 393, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 393, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
@@ -396,13 +390,14 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(37, 25);
 
                 //Carteira (no arquivo retorno, vem com 1 caracter. Ajustamos para 2 caracteres, como no manual do Bradesco.
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(107, 1).PadLeft(2, '0');
-                boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                var contaBancaria = boleto.Banco.Cedente.ContaBancaria;
+                contaBancaria.Carteira = registro.Substring(107, 1).PadLeft(2, '0');
+                contaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
 
                 //Identificação do Título no Banco
                 boleto.NossoNumero = registro.Substring(70, 11);//Sem o DV
                 boleto.NossoNumeroDV = registro.Substring(81, 1); //DV
-                boleto.NossoNumeroFormatado = string.Format("{0}/{1}-{2}", boleto.Banco.Cedente.ContaBancaria.Carteira, boleto.NossoNumero, boleto.NossoNumeroDV);
+                boleto.NossoNumeroFormatado = $"{contaBancaria.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
 
                 //Identificação de Ocorrência
                 boleto.CodigoOcorrencia = registro.Substring(108, 2);
@@ -415,8 +410,8 @@ namespace Boleto2Net
 
                 //Valores do Título
                 boleto.ValorTitulo = Convert.ToDecimal(registro.Substring(152, 13)) / 100;
-                boleto.ValorTarifas = (Convert.ToDecimal(registro.Substring(175, 13)) / 100);
-                boleto.ValorOutrasDespesas = (Convert.ToDecimal(registro.Substring(188, 13)) / 100);
+                boleto.ValorTarifas = Convert.ToDecimal(registro.Substring(175, 13)) / 100;
+                boleto.ValorOutrasDespesas = Convert.ToDecimal(registro.Substring(188, 13)) / 100;
                 boleto.ValorIOF = Convert.ToDecimal(registro.Substring(214, 13)) / 100;
                 boleto.ValorAbatimento = Convert.ToDecimal(registro.Substring(227, 13)) / 100;
                 boleto.ValorDesconto = Convert.ToDecimal(registro.Substring(240, 13)) / 100;
@@ -510,15 +505,15 @@ namespace Boleto2Net
         {
             string digito;
             int pesoMaximo = 7, soma = 0, peso = 2;
-            for (int i = (texto.Length - 1); i >= 0; i--)
+            for (var i = texto.Length - 1; i >= 0; i--)
             {
-                soma = soma + (Convert.ToInt32(texto.Substring(i, 1)) * peso);
+                soma = soma + Convert.ToInt32(texto.Substring(i, 1)) * peso;
                 if (peso == pesoMaximo)
                     peso = 2;
                 else
                     peso = peso + 1;
             }
-            int resto = (soma % 11);
+            var resto = soma % 11;
             switch (resto)
             {
                 case 0:

--- a/Boleto2.Net/Banco/Banco_Caixa.cs
+++ b/Boleto2.Net/Banco/Banco_Caixa.cs
@@ -1,37 +1,38 @@
 using System;
 using System.Web.UI;
+using static System.String;
 
 [assembly: WebResource("BoletoNet.Imagens.104.jpg", "image/jpg")]
 
 namespace Boleto2Net
 {
-    internal class Banco_Caixa : AbstractBanco
+    internal sealed class BancoCaixa : AbstractBanco
     {
-        internal Banco_Caixa()
+        internal BancoCaixa()
         {
-            this.Codigo = 104;
-            this.Digito = "0";
-            this.Nome = "Caixa Econômica Federal";
+            Codigo = 104;
+            Digito = "0";
+            Nome = "Caixa Econômica Federal";
         }
 
         public override void FormataCedente()
         {
-            if (this.Cedente.Codigo.Length > 6)
-                throw new Exception("O código do cedente (" + this.Cedente.Codigo + ") deve conter 6 dígitos.");
-            else if (this.Cedente.Codigo.Length < 6)
-                this.Cedente.Codigo = this.Cedente.Codigo.PadLeft(6, '0');
+            if (Cedente.Codigo.Length > 6)
+                throw new Exception($"O código do cedente ({Cedente.Codigo}) deve conter 6 dígitos.");
+            if (Cedente.Codigo.Length < 6)
+                Cedente.Codigo = Cedente.Codigo.PadLeft(6, '0');
 
-            string dv = CalcularDV(this.Cedente.CodigoDV);
-            if (this.Cedente.CodigoDV == string.Empty)
-                throw new Exception("Dígito do código do cedente (" + this.Cedente.Codigo + ") não foi informado.");
+            string dv = CalcularDV(Cedente.CodigoDV);
+            if (Cedente.CodigoDV == Empty)
+                throw new Exception($"Dígito do código do cedente ({Cedente.Codigo}) não foi informado.");
 
-            this.Cedente.CodigoFormatado = String.Format("{0}/{1}-{2}", this.Cedente.ContaBancaria.Agencia, this.Cedente.Codigo, this.Cedente.CodigoDV);
+            Cedente.CodigoFormatado = $"{Cedente.ContaBancaria.Agencia}/{Cedente.Codigo}-{Cedente.CodigoDV}";
 
-            this.Cedente.ContaBancaria.LocalPagamento = "ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NA CAIXA ECONÔMICA FEDERAL.";
+            Cedente.ContaBancaria.LocalPagamento = "ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NA CAIXA ECONÔMICA FEDERAL.";
 
-            if (this.Cedente.ContaBancaria.CarteiraComVariacao != "SIG14")
+            if (Cedente.ContaBancaria.CarteiraComVariacao != "SIG14")
             {
-                throw new NotImplementedException("Carteira não implementada: " + this.Cedente.ContaBancaria.CarteiraComVariacao);
+                throw new NotImplementedException("Carteira não implementada: " + Cedente.ContaBancaria.CarteiraComVariacao);
             }
         }
 
@@ -41,7 +42,7 @@ namespace Boleto2Net
 
         public override void FormataNossoNumero(Boleto boleto)
         {
-            if (boleto.Banco.Cedente.ContaBancaria.Carteira.Equals("SIG14") & String.IsNullOrWhiteSpace(boleto.Banco.Cedente.ContaBancaria.VariacaoCarteira))
+            if (boleto.Banco.Cedente.ContaBancaria.Carteira.Equals("SIG14") & IsNullOrWhiteSpace(boleto.Banco.Cedente.ContaBancaria.VariacaoCarteira))
             {
                 FormataNossoNumero_SIG14(boleto);
             }
@@ -55,11 +56,11 @@ namespace Boleto2Net
         {
             // Carteira SIG14: Dúvida: Se o Cliente SEMPRE emite o boleto, pois o nosso número começa com 14, o que significa Título Registrado emissão Empresa:
             // O nosso número não pode ser em branco.
-            if (String.IsNullOrWhiteSpace(boleto.NossoNumero))
+            if (IsNullOrWhiteSpace(boleto.NossoNumero))
             {
                 throw new Exception("Nosso Número não informado.");
             }
-            else if (boleto.NossoNumero.Length == 17)
+            if (boleto.NossoNumero.Length == 17)
             {
                 // O nosso número deve estar formatado corretamente (com 17 dígitos e iniciando com o "14"),
                 if (!boleto.NossoNumero.StartsWith("14"))
@@ -70,16 +71,15 @@ namespace Boleto2Net
                 // Ou deve ser informado com até 15 posições (será formatado para 17 dígitos pelo Boleto.Net).
                 if (boleto.NossoNumero.Length > 15)
                     throw new Exception("Nosso Número (" + boleto.NossoNumero + ") deve iniciar com \"14\" e conter 17 dígitos.");
-                else
-                    boleto.NossoNumero = "14" + boleto.NossoNumero.PadLeft(15, '0');
+                boleto.NossoNumero = "14" + boleto.NossoNumero.PadLeft(15, '0');
             }
             boleto.NossoNumeroDV = CalcularDV(boleto.NossoNumero);
-            boleto.NossoNumeroFormatado = string.Format("{0}-{1}", boleto.NossoNumero, boleto.NossoNumeroDV);
+            boleto.NossoNumeroFormatado = Format("{0}-{1}", boleto.NossoNumero, boleto.NossoNumeroDV);
         }
 
         public override string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            string FormataCampoLivre = "";
+            string formataCampoLivre = "";
             if (boleto.Banco.Cedente.ContaBancaria.Carteira == "SIG14")
             {
                 // Posição 20 - 25 - Código do Cedente
@@ -90,7 +90,7 @@ namespace Boleto2Net
                 // Posição 34 - Código 4 - Emissão do boleto pelo cedente
                 // Posição 35 - 43 - De acordo com documentaçao, posição 9 a 17 do nosso numero
                 // Posição 44 - Dígito Verificador
-                FormataCampoLivre = string.Format("{0}{1}{2}{3}{4}{5}{6}",
+                formataCampoLivre = Format("{0}{1}{2}{3}{4}{5}{6}",
                                            boleto.Banco.Cedente.Codigo,
                                            boleto.Banco.Cedente.CodigoDV,
                                            boleto.NossoNumero.Substring(2, 3),
@@ -98,33 +98,33 @@ namespace Boleto2Net
                                            boleto.NossoNumero.Substring(5, 3),
                                            "4",
                                            boleto.NossoNumero.Substring(8, 9));
-                FormataCampoLivre += CalcularDV(FormataCampoLivre).ToString();
+                formataCampoLivre += CalcularDV(formataCampoLivre).ToString();
             }
             else
             {
                 throw new NotImplementedException("Não foi possível formatar o campo livre do código de barras do boleto.");
             }
-            return FormataCampoLivre;
+            return formataCampoLivre;
         }
 
         public override string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)
         {
             try
             {
-                string _header = String.Empty;
+                string header = Empty;
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB240:
                         // Cabeçalho do Arquivo
-                        _header += GerarHeaderRemessaCNAB240SIGCB(numeroArquivoRemessa, ref numeroRegistroGeral);
+                        header += GerarHeaderRemessaCNAB240SIGCB(numeroArquivoRemessa, ref numeroRegistroGeral);
                         // Cabeçalho do Lote
-                        _header += Environment.NewLine;
-                        _header += GerarHeaderLoteRemessaCNAB240SIGCB(numeroArquivoRemessa, ref numeroRegistroGeral);
+                        header += Environment.NewLine;
+                        header += GerarHeaderLoteRemessaCNAB240SIGCB(numeroArquivoRemessa, ref numeroRegistroGeral);
                         break;
                     default:
                         throw new Exception("Header - Tipo de arquivo inexistente.");
                 }
-                return _header;
+                return header;
             }
             catch (Exception ex)
             {
@@ -136,33 +136,33 @@ namespace Boleto2Net
         {
             try
             {
-                string _detalhe = String.Empty;
-                string _strline = "";
+                string detalhe = Empty;
+                string strline = "";
                 //base.GerarDetalheRemessa(boleto, numeroRegistro, tipoArquivo);
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB240:
                         // Segmento P (Obrigatório)
-                        _detalhe += this.GerarDetalheSegmentoPRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
+                        detalhe += GerarDetalheSegmentoPRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
 
                         // Segmento Q (Obrigatório)
-                        _detalhe += Environment.NewLine;
-                        _detalhe += this.GerarDetalheSegmentoQRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
+                        detalhe += Environment.NewLine;
+                        detalhe += GerarDetalheSegmentoQRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
 
                         // Segmento R (Opcional)
-                        _strline = this.GerarDetalheSegmentoRRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
-                        if (!String.IsNullOrWhiteSpace(_strline))
+                        strline = GerarDetalheSegmentoRRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
+                        if (!IsNullOrWhiteSpace(strline))
                         {
-                            _detalhe += Environment.NewLine;
-                            _detalhe += _strline;
+                            detalhe += Environment.NewLine;
+                            detalhe += strline;
                         }
 
                         // Segmento S (Opcional)
-                        _strline = this.GerarDetalheSegmentoSRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
-                        if (!String.IsNullOrWhiteSpace(_strline))
+                        strline = GerarDetalheSegmentoSRemessaCNAB240SIGCB(boleto, ref numeroRegistro);
+                        if (!IsNullOrWhiteSpace(strline))
                         {
-                            _detalhe += Environment.NewLine;
-                            _detalhe += _strline;
+                            detalhe += Environment.NewLine;
+                            detalhe += strline;
                         }
 
                         break;
@@ -170,7 +170,7 @@ namespace Boleto2Net
                         throw new Exception("Caixa Econômica Federal - Detalhe - Tipo de arquivo inexistente.");
                 }
 
-                return _detalhe;
+                return detalhe;
 
             }
             catch (Exception ex)
@@ -188,23 +188,23 @@ namespace Boleto2Net
         {
             try
             {
-                string _trailler = String.Empty;
+                string trailler = Empty;
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB240:
                         // Trailler do Lote
-                        _trailler += GerarTrailerLoteRemessaCNAC240SIGCB(ref numeroRegistroGeral,
+                        trailler += GerarTrailerLoteRemessaCNAC240SIGCB(ref numeroRegistroGeral,
                                                                                 numeroRegistroCobrancaSimples, valorCobrancaSimples,
                                                                                 numeroRegistroCobrancaCaucionada, valorCobrancaCaucionada,
                                                                                 numeroRegistroCobrancaDescontada, valorCobrancaDescontada);
                         // Trailler do Arquivo
-                        _trailler += Environment.NewLine;
-                        _trailler += GerarTrailerRemessaCNAB240SIGCB(ref numeroRegistroGeral);
+                        trailler += Environment.NewLine;
+                        trailler += GerarTrailerRemessaCNAB240SIGCB(ref numeroRegistroGeral);
                         break;
                     default:
                         throw new Exception("Caixa Econômica Federal - Trailler - Tipo de arquivo inexistente.");
                 }
-                return _trailler;
+                return trailler;
             }
             catch (Exception ex)
             {
@@ -221,28 +221,28 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 003, 0, "104", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0004, 004, 0, "0000", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, this.Cedente.TipoCPFCNPJ("0"), '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 014, 0, this.Cedente.CPFCNPJ, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, Cedente.TipoCPFCNPJ("0"), '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 014, 0, Cedente.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0033, 020, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 005, 0, this.Cedente.ContaBancaria.Agencia, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0058, 001, 0, this.Cedente.ContaBancaria.DigitoAgencia, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 006, 0, this.Cedente.Codigo, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 005, 0, Cedente.ContaBancaria.Agencia, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0058, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 006, 0, Cedente.Codigo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0065, 007, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0072, 001, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 030, 0, this.Cedente.Nome, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 030, 0, Cedente.Nome, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0103, 030, 0, "CAIXA ECONOMICA FEDERAL", ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0133, 010, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0133, 010, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0143, 001, 0, "1", '0');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0144, 008, 0, DateTime.Now, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediHoraHHMMSS___________, 0152, 006, 0, DateTime.Now, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0158, 006, 0, numeroArquivoRemessa, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0164, 003, 0, "050", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0167, 005, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0172, 020, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0172, 020, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0192, 020, 0, "REMESSA-PRODUCAO", ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0212, 004, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0216, 025, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0212, 004, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0216, 025, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }
@@ -263,23 +263,23 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0010, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0012, 002, 0, "00", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0014, 003, 0, "030", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0017, 001, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, this.Cedente.TipoCPFCNPJ("0"), '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 015, 0, this.Cedente.CPFCNPJ, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0034, 006, 0, this.Cedente.Codigo, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0017, 001, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, Cedente.TipoCPFCNPJ("0"), '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 015, 0, Cedente.CPFCNPJ, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0034, 006, 0, Cedente.Codigo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0040, 014, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0054, 005, 0, this.Cedente.ContaBancaria.Agencia, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0059, 001, 0, this.Cedente.ContaBancaria.DigitoAgencia, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0060, 006, 0, this.Cedente.Codigo, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0054, 005, 0, Cedente.ContaBancaria.Agencia, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0059, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0060, 006, 0, Cedente.Codigo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0066, 007, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0073, 001, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 030, 0, this.Cedente.Nome, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0104, 040, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0144, 040, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 030, 0, Cedente.Nome, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0104, 040, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0144, 040, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0184, 008, 0, numeroArquivoRemessa, '0');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0192, 008, 0, DateTime.Now, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0200, 008, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0208, 033, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0208, 033, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }
@@ -299,7 +299,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "3", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0009, 005, 0, numeroRegistroGeral, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0014, 001, 0, "P", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 005, 0, boleto.Banco.Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0023, 001, 0, boleto.Banco.Cedente.ContaBancaria.DigitoAgencia, ' ');
@@ -313,7 +313,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0061, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0062, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0063, 011, 0, boleto.NumeroDocumento, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 004, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 004, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0078, 008, 0, boleto.DataVencimento, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0086, 015, 2, boleto.ValorTitulo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0101, 005, 2, "0", '0');
@@ -328,7 +328,8 @@ namespace Boleto2Net
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0119, 008, 0, "0", '0');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 015, 2, 0, '0');
                 }
-                else {
+                else
+                {
                     // Com Juros Mora ($)
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0118, 001, 2, "1", '0');
                     reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0119, 008, 0, boleto.DataJuros, '0');
@@ -357,7 +358,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0225, 003, 0, boleto.DiasBaixaDevolucao, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0228, 002, 0, "09", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0230, 010, 2, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0240, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0240, 001, 0, Empty, ' ');
                 reg.CodificarLinha();
                 string vLinha = reg.LinhaRegistro;
                 return vLinha;
@@ -379,7 +380,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "3", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0009, 005, 0, numeroRegistroGeral, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0014, 001, 0, "Q", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, boleto.Sacado.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 015, 0, boleto.Sacado.CPFCNPJ, '0');
@@ -392,9 +393,9 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0154, 001, 0, boleto.Avalista.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0155, 015, 0, boleto.Avalista.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0170, 040, 0, boleto.Avalista.Nome, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 020, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0233, 008, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 020, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0233, 008, 0, Empty, ' ');
                 reg.CodificarLinha();
                 string vLinha = reg.LinhaRegistro;
                 return vLinha;
@@ -408,14 +409,14 @@ namespace Boleto2Net
         {
             try
             {
-                string CodMulta;
+                string codMulta;
                 if (boleto.ValorMulta > 0)
-                    CodMulta = "1";
+                    codMulta = "1";
                 else
-                    CodMulta = "0";
+                    codMulta = "0";
                 string msg3 = Utils.FitStringLength(boleto.MensagemArquivoRemessa.PadRight(500, ' ').Substring(00, 40), 40, 40, ' ', 0, true, true, false);
                 string msg4 = Utils.FitStringLength(boleto.MensagemArquivoRemessa.PadRight(500, ' ').Substring(40, 40), 40, 40, ' ', 0, true, true, false);
-                if (CodMulta == "0" & String.IsNullOrWhiteSpace(msg3) & String.IsNullOrWhiteSpace(msg4))
+                if (codMulta == "0" & IsNullOrWhiteSpace(msg3) & IsNullOrWhiteSpace(msg4))
                     return "";
 
                 numeroRegistroGeral++;
@@ -425,7 +426,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "3", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0009, 005, 0, numeroRegistroGeral, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0014, 001, 0, "R", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 008, 0, "0", '0');
@@ -433,14 +434,14 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0042, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0043, 008, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0051, 015, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0066, 001, 0, CodMulta, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0066, 001, 0, codMulta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAAAA_________, 0067, 008, 0, boleto.DataMulta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 015, 2, boleto.ValorMulta, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0090, 010, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0090, 010, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0100, 040, 0, msg3, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0140, 040, 0, msg4, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0180, 050, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0230, 011, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0180, 050, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0230, 011, 0, Empty, ' ');
                 reg.CodificarLinha();
                 string vLinha = reg.LinhaRegistro;
                 return vLinha;
@@ -454,8 +455,8 @@ namespace Boleto2Net
         {
             try
             {
-                string msg5a9 = Utils.FitStringLength(boleto.MensagemArquivoRemessa.PadRight(500, ' ').Substring(80, 200), 200, 200, ' ', 0, true, true, false);
-                if (String.IsNullOrWhiteSpace(msg5a9))
+                string msg5A9 = Utils.FitStringLength(boleto.MensagemArquivoRemessa.PadRight(500, ' ').Substring(80, 200), 200, 200, ' ', 0, true, true, false);
+                if (IsNullOrWhiteSpace(msg5A9))
                     return "";
 
                 numeroRegistroGeral++;
@@ -465,11 +466,11 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "3", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0009, 005, 0, numeroRegistroGeral, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0014, 001, 0, "S", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0015, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0016, 002, 0, "01", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, "3", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0019, 200, 0, msg5a9, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0219, 022, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0019, 200, 0, msg5A9, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0219, 022, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }
@@ -491,7 +492,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 003, 0, "104", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0004, 004, 0, "0001", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "5", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 006, 0, numeroRegistrosNoLote, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 006, 0, numeroRegistroCobrancaSimples, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0030, 017, 2, valorCobrancaSimples, '0');
@@ -499,8 +500,8 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 017, 2, valorCobrancaCaucionada, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0070, 006, 0, numeroRegistroCobrancaDescontada, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0076, 017, 2, valorCobrancaDescontada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0093, 031, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0124, 117, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0093, 031, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0124, 117, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }
@@ -519,11 +520,11 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 003, 0, "104", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0004, 004, 0, "9999", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0008, 001, 0, "9", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 006, 0, "1", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 006, 0, numeroRegistrosNoArquivo, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0030, 006, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0036, 205, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0030, 006, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0036, 205, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }
@@ -560,7 +561,7 @@ namespace Boleto2Net
                 //Identificação do Título no Banco
                 boleto.NossoNumero = registro.Substring(39, 17);
                 boleto.NossoNumeroDV = registro.Substring(56, 1);
-                boleto.NossoNumeroFormatado = string.Format("{0}-{1}", boleto.NossoNumero, boleto.NossoNumeroDV);
+                boleto.NossoNumeroFormatado = Format("{0}-{1}", boleto.NossoNumero, boleto.NossoNumeroDV);
 
                 //Identificação de Ocorrência
                 boleto.CodigoOcorrencia = registro.Substring(15, 2);

--- a/Boleto2.Net/Boleto2.Net.csproj
+++ b/Boleto2.Net/Boleto2.Net.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Enums\TipoCodigoBaixa.cs" />
     <Compile Include="Enums\TipoCodigoProtesto.cs" />
     <Compile Include="Enums\TipoEspecieDocumento.cs" />
+    <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Util\EDIBasicTypes.cs" />
     <Compile Include="Enums\TipoCarteira.cs" />
     <Compile Include="Enums\TipoFormaCadastramento.cs" />

--- a/Boleto2.Net/Boleto2.Net.v3.ncrunchproject
+++ b/Boleto2.Net/Boleto2.Net.v3.ncrunchproject
@@ -1,0 +1,8 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoredTests>
+      <AllTestsSelector />
+    </IgnoredTests>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Boleto2.Net/Boleto2NetProxy.cs
+++ b/Boleto2.Net/Boleto2NetProxy.cs
@@ -569,7 +569,7 @@ namespace Boleto2Net
                     using (BoletoBancario imprimeBoleto = new BoletoBancario
                     {
                         //CodigoBanco = (short)boletoTmp.Banco.Codigo,
-                        boleto = boletoTmp,
+                        Boleto = boletoTmp,
                         OcultarInstrucoes = false,
                         MostrarComprovanteEntrega = true,
                         MostrarEnderecoCedente = true

--- a/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
+++ b/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
@@ -2,13 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Text;
-using System.Web.UI;
 //Envio por email
 using System.IO;
 using System.Net.Mail;
 using System.Net.Mime;
 using System.Reflection;
+using System.Text;
+using System.Web.UI;
 
 [assembly: WebResource("Boleto2Net.BoletoImpressao.BoletoNet.css", "text/css", PerformSubstitution = true)]
 [assembly: WebResource("Boleto2Net.Imagens.barra.gif", "image/gif")]
@@ -21,9 +21,9 @@ namespace Boleto2Net
     Designer(typeof(BoletoBancarioDesigner)),
     ToolboxBitmap(typeof(BoletoBancario)),
     ToolboxData("<{0}:BoletoBancario Runat=\"server\"></{0}:BoletoBancario>")]
-    public class BoletoBancario : System.Web.UI.Control
+    public class BoletoBancario : Control
     {
-        String vLocalLogoCedente = String.Empty;
+        String _vLocalLogoCedente = String.Empty;
 
         #region Variaveis
 
@@ -58,7 +58,7 @@ namespace Boleto2Net
         }
 
         [Browsable(false)]
-        public Boleto boleto { get; set; }
+        public Boleto Boleto { get; set; }
 
         [Browsable(false)]
         public Banco Banco { get; set; }
@@ -148,8 +148,8 @@ namespace Boleto2Net
         #region Override
         protected override void OnPreRender(EventArgs e)
         {
-            string alias = "Boleto2Net.BoletoImpressao.BoletoNet.css";
-            string csslink = "<link rel=\"stylesheet\" type=\"text/css\" href=\"" +
+            var alias = "Boleto2Net.BoletoImpressao.BoletoNet.css";
+            var csslink = "<link rel=\"stylesheet\" type=\"text/css\" href=\"" +
                 Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), alias) + "\" />";
 
             var include = new LiteralControl(csslink);
@@ -165,8 +165,8 @@ namespace Boleto2Net
         [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.Demand, Name = "Execution")]
         protected override void Render(HtmlTextWriter output)
         {
-            string urlImagemLogo = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "Boleto2Net.Imagens." + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg");
-            string urlImagemBarra = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "Boleto2Net.Imagens.barra.gif");
+            var urlImagemLogo = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "Boleto2Net.Imagens." + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg");
+            var urlImagemBarra = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "Boleto2Net.Imagens.barra.gif");
             //string urlImagemBarraInterna = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.barrainterna.gif");
             //string urlImagemCorte = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.corte.gif");
             //string urlImagemPonto = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.ponto.gif");
@@ -174,7 +174,7 @@ namespace Boleto2Net
             //Atribui os valores ao html do boleto bancário
             //output.Write(MontaHtml(urlImagemCorte, urlImagemLogo, urlImagemBarra, urlImagemPonto, urlImagemBarraInterna,
             //    "<img src=\"ImagemCodigoBarra.ashx?code=" + Boleto.CodigoBarra.Codigo + "\" alt=\"Código de Barras\" />"));
-            output.Write(MontaHtml(urlImagemLogo, urlImagemBarra, "<img src=\"ImagemCodigoBarra.ashx?code=" + boleto.CodigoBarra.CodigoDeBarras + "\" alt=\"Código de Barras\" />"));
+            output.Write(MontaHtml(urlImagemLogo, urlImagemBarra, "<img src=\"ImagemCodigoBarra.ashx?code=" + Boleto.CodigoBarra.CodigoDeBarras + "\" alt=\"Código de Barras\" />"));
         }
         #endregion Override
 
@@ -185,8 +185,8 @@ namespace Boleto2Net
             {
                 var html = new StringBuilder();
 
-                string titulo = "Instruções de Impressão";
-                string instrucoes = "Imprimir em impressora jato de tinta (ink jet) ou laser em qualidade normal. (Não use modo econômico).<br>Utilize folha A4 (210 x 297 mm) ou Carta (216 x 279 mm) - Corte na linha indicada<br>";
+                var titulo = "Instruções de Impressão";
+                var instrucoes = "Imprimir em impressora jato de tinta (ink jet) ou laser em qualidade normal. (Não use modo econômico).<br>Utilize folha A4 (210 x 297 mm) ou Carta (216 x 279 mm) - Corte na linha indicada<br>";
 
                 html.Append(Html.Instrucoes);
                 html.Append("<br />");
@@ -285,13 +285,13 @@ namespace Boleto2Net
         private string MontaHtml(string urlImagemLogo, string urlImagemBarra, string imagemCodigoBarras)
         {
             var html = new StringBuilder();
-            string enderecoCedente = "";
+            var enderecoCedente = "";
 
             //Oculta o cabeçalho das instruções do boleto
             if (!OcultarInstrucoes)
                 html.Append(GeraHtmlInstrucoes());
 
-            if (this.ExibirDemonstrativo && this.boleto.Demonstrativos.Any())
+            if (ExibirDemonstrativo && Boleto.Demonstrativos.Any())
             {
                 html.Append(Html.ReciboCedenteRelatorioValores);
                 html.Append(Html.ReciboCedenteParte5);
@@ -300,7 +300,7 @@ namespace Boleto2Net
 
                 var grupoDemonstrativo = new StringBuilder();
 
-                foreach (var relatorio in this.boleto.Demonstrativos)
+                foreach (var relatorio in Boleto.Demonstrativos)
                 {
                     var first = true;
 
@@ -352,57 +352,57 @@ namespace Boleto2Net
                     //Caso mostre o Endereço do Cedente
                     if (MostrarEnderecoCedente)
                     {
-                        if (boleto.Banco.Cedente.Endereco == null)
+                        if (Boleto.Banco.Cedente.Endereco == null)
                             throw new ArgumentNullException("Endereço do Cedente");
 
                         enderecoCedente = string.Format("{0} - {1} - {2}/{3} - CEP: {4}",
-                                                            boleto.Banco.Cedente.Endereco.FormataLogradouro(0),
-                                                            boleto.Banco.Cedente.Endereco.Bairro,
-                                                            boleto.Banco.Cedente.Endereco.Cidade,
-                                                            boleto.Banco.Cedente.Endereco.UF,
-                                                            Utils.FormataCEP(boleto.Banco.Cedente.Endereco.CEP));
+                                                            Boleto.Banco.Cedente.Endereco.FormataLogradouro(0),
+                                                            Boleto.Banco.Cedente.Endereco.Bairro,
+                                                            Boleto.Banco.Cedente.Endereco.Cidade,
+                                                            Boleto.Banco.Cedente.Endereco.UF,
+                                                            Utils.FormataCEP(Boleto.Banco.Cedente.Endereco.CEP));
                     }
                 }
             }
 
             // Dados do Sacado
-            var sacado = boleto.Sacado.Nome;
-            switch (boleto.Sacado.TipoCPFCNPJ("A"))
+            var sacado = Boleto.Sacado.Nome;
+            switch (Boleto.Sacado.TipoCPFCNPJ("A"))
             {
                 case "F":
-                    sacado += string.Format(" - CPF: " + Utils.FormataCPF(boleto.Sacado.CPFCNPJ));
+                    sacado += string.Format(" - CPF: " + Utils.FormataCPF(Boleto.Sacado.CPFCNPJ));
                     break;
                 case "J":
-                    sacado += string.Format(" - CNPJ: " + Utils.FormataCPF(boleto.Sacado.CPFCNPJ));
+                    sacado += string.Format(" - CNPJ: " + Utils.FormataCPF(Boleto.Sacado.CPFCNPJ));
                     break;
             }
-            if (boleto.Sacado.Observacoes != string.Empty)
-                sacado += " - " + boleto.Sacado.Observacoes;
+            if (Boleto.Sacado.Observacoes != string.Empty)
+                sacado += " - " + Boleto.Sacado.Observacoes;
 
             var enderecoSacado = string.Empty;
             if (!OcultarEnderecoSacado)
             {
-                enderecoSacado = boleto.Sacado.Endereco.FormataLogradouro(0) + "<br />" + string.Format("{0} - {1}/{2}", boleto.Sacado.Endereco.Bairro, boleto.Sacado.Endereco.Cidade, boleto.Sacado.Endereco.UF);
-                if (boleto.Sacado.Endereco.CEP != String.Empty)
-                    enderecoSacado += string.Format(" - CEP: {0}", Utils.FormataCEP(boleto.Sacado.Endereco.CEP));
+                enderecoSacado = Boleto.Sacado.Endereco.FormataLogradouro(0) + "<br />" + string.Format("{0} - {1}/{2}", Boleto.Sacado.Endereco.Bairro, Boleto.Sacado.Endereco.Cidade, Boleto.Sacado.Endereco.UF);
+                if (Boleto.Sacado.Endereco.CEP != String.Empty)
+                    enderecoSacado += string.Format(" - CEP: {0}", Utils.FormataCEP(Boleto.Sacado.Endereco.CEP));
             }
 
             // Dados do Avalista
             var avalista = string.Empty;
-            if (boleto.Avalista.Nome != string.Empty)
+            if (Boleto.Avalista.Nome != string.Empty)
             {
-                avalista = boleto.Avalista.Nome;
-                switch (boleto.Avalista.TipoCPFCNPJ("A"))
+                avalista = Boleto.Avalista.Nome;
+                switch (Boleto.Avalista.TipoCPFCNPJ("A"))
                 {
                     case "F":
-                        sacado += string.Format(" - CPF: " + Utils.FormataCPF(boleto.Sacado.CPFCNPJ));
+                        sacado += string.Format(" - CPF: " + Utils.FormataCPF(Boleto.Sacado.CPFCNPJ));
                         break;
                     case "J":
-                        sacado += string.Format(" - CNPJ: " + Utils.FormataCPF(boleto.Sacado.CPFCNPJ));
+                        sacado += string.Format(" - CNPJ: " + Utils.FormataCPF(Boleto.Sacado.CPFCNPJ));
                         break;
                 }
-                if (boleto.Avalista.Observacoes != string.Empty)
-                    avalista += " - " + boleto.Avalista.Observacoes;
+                if (Boleto.Avalista.Observacoes != string.Empty)
+                    avalista += " - " + Boleto.Avalista.Observacoes;
             }
 
 
@@ -413,52 +413,52 @@ namespace Boleto2Net
                 html.Append(GeraHtmlCarne("", GeraHtmlReciboCedente()));
             }
 
-            string dataVencimento = boleto.DataVencimento.ToString("dd/MM/yyyy");
+            var dataVencimento = Boleto.DataVencimento.ToString("dd/MM/yyyy");
 
             if (MostrarContraApresentacaoNaDataVencimento)
                 dataVencimento = "Contra Apresentação";
 
-            if (String.IsNullOrWhiteSpace(vLocalLogoCedente))
-                vLocalLogoCedente = urlImagemLogo;
+            if (String.IsNullOrWhiteSpace(_vLocalLogoCedente))
+                _vLocalLogoCedente = urlImagemLogo;
 
             return html
-                .Replace("@CODIGOBANCO", Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3))
-                .Replace("@DIGITOBANCO", boleto.Banco.Digito.ToString())
+                .Replace("@CODIGOBANCO", Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3))
+                .Replace("@DIGITOBANCO", Boleto.Banco.Digito.ToString())
                 .Replace("@URLIMAGEMLOGO", urlImagemLogo)
-                .Replace("@URLIMGCEDENTE", vLocalLogoCedente)
+                .Replace("@URLIMGCEDENTE", _vLocalLogoCedente)
                 .Replace("@URLIMAGEMBARRA", urlImagemBarra)
-                .Replace("@LINHADIGITAVEL", boleto.CodigoBarra.LinhaDigitavel)
-                .Replace("@LOCALPAGAMENTO", boleto.Banco.Cedente.ContaBancaria.LocalPagamento)
+                .Replace("@LINHADIGITAVEL", Boleto.CodigoBarra.LinhaDigitavel)
+                .Replace("@LOCALPAGAMENTO", Boleto.Banco.Cedente.ContaBancaria.LocalPagamento)
                 .Replace("@DATAVENCIMENTO", dataVencimento)
-                .Replace("@CEDENTE_BOLETO", !boleto.Banco.Cedente.MostrarCNPJnoBoleto ? boleto.Banco.Cedente.Nome : string.Format("{0}&nbsp;&nbsp;&nbsp;CNPJ: {1}", boleto.Banco.Cedente.Nome, boleto.Banco.Cedente.CPFCNPJ))
-                .Replace("@CEDENTE", boleto.Banco.Cedente.Nome)
-                .Replace("@DATADOCUMENTO", boleto.DataEmissao.ToString("dd/MM/yyyy"))
-                .Replace("@NUMERODOCUMENTO", boleto.NumeroDocumento)
-                .Replace("@ESPECIEDOCUMENTO", boleto.EspecieDocumento.ToString())
-                .Replace("@DATAPROCESSAMENTO", boleto.DataProcessamento.ToString("dd/MM/yyyy"))
-                .Replace("@NOSSONUMERO", boleto.NossoNumeroFormatado)
-                .Replace("@CARTEIRA", boleto.Banco.Cedente.ContaBancaria.Carteira)
-                .Replace("@ESPECIE", boleto.EspecieMoeda)
-                .Replace("@QUANTIDADE", (boleto.QuantidadeMoeda == 0 ? "" : boleto.QuantidadeMoeda.ToString()))
-                .Replace("@VALORDOCUMENTO", boleto.ValorMoeda)
-                .Replace("@=VALORDOCUMENTO", (boleto.ValorTitulo == 0 ? "" : boleto.ValorTitulo.ToString("R$ ##,##0.00")))
-                .Replace("@VALORCOBRADO", (boleto.ValorPago == 0 ? "" : boleto.ValorPago.ToString("R$ ##,##0.00")))
+                .Replace("@CEDENTE_BOLETO", !Boleto.Banco.Cedente.MostrarCNPJnoBoleto ? Boleto.Banco.Cedente.Nome : string.Format("{0}&nbsp;&nbsp;&nbsp;CNPJ: {1}", Boleto.Banco.Cedente.Nome, Boleto.Banco.Cedente.CPFCNPJ))
+                .Replace("@CEDENTE", Boleto.Banco.Cedente.Nome)
+                .Replace("@DATADOCUMENTO", Boleto.DataEmissao.ToString("dd/MM/yyyy"))
+                .Replace("@NUMERODOCUMENTO", Boleto.NumeroDocumento)
+                .Replace("@ESPECIEDOCUMENTO", Boleto.EspecieDocumento.ToString())
+                .Replace("@DATAPROCESSAMENTO", Boleto.DataProcessamento.ToString("dd/MM/yyyy"))
+                .Replace("@NOSSONUMERO", Boleto.NossoNumeroFormatado)
+                .Replace("@CARTEIRA", Boleto.Banco.Cedente.ContaBancaria.Carteira)
+                .Replace("@ESPECIE", Boleto.EspecieMoeda)
+                .Replace("@QUANTIDADE", (Boleto.QuantidadeMoeda == 0 ? "" : Boleto.QuantidadeMoeda.ToString()))
+                .Replace("@VALORDOCUMENTO", Boleto.ValorMoeda)
+                .Replace("@=VALORDOCUMENTO", (Boleto.ValorTitulo == 0 ? "" : Boleto.ValorTitulo.ToString("R$ ##,##0.00")))
+                .Replace("@VALORCOBRADO", (Boleto.ValorPago == 0 ? "" : Boleto.ValorPago.ToString("R$ ##,##0.00")))
                 .Replace("@OUTROSACRESCIMOS", "")
                 .Replace("@OUTRASDEDUCOES", "")
-                .Replace("@DESCONTOS", (boleto.ValorDesconto == 0 ? "" : boleto.ValorDesconto.ToString("R$ ##,##0.00")))
-                .Replace("@AGENCIACONTA", boleto.Banco.Cedente.CodigoFormatado)
+                .Replace("@DESCONTOS", (Boleto.ValorDesconto == 0 ? "" : Boleto.ValorDesconto.ToString("R$ ##,##0.00")))
+                .Replace("@AGENCIACONTA", Boleto.Banco.Cedente.CodigoFormatado)
                 .Replace("@SACADO", sacado)
                 .Replace("@ENDERECOSACADO", enderecoSacado)
                 .Replace("@AVALISTA", avalista)
-                .Replace("@AGENCIACODIGOCEDENTE", boleto.Banco.Cedente.CodigoFormatado)
-                .Replace("@CPFCNPJ", boleto.Banco.Cedente.CPFCNPJ)
-                .Replace("@MORAMULTA", (boleto.ValorMulta == 0 ? "" : boleto.ValorMulta.ToString("R$ ##,##0.00")))
+                .Replace("@AGENCIACODIGOCEDENTE", Boleto.Banco.Cedente.CodigoFormatado)
+                .Replace("@CPFCNPJ", Boleto.Banco.Cedente.CPFCNPJ)
+                .Replace("@MORAMULTA", (Boleto.ValorMulta == 0 ? "" : Boleto.ValorMulta.ToString("R$ ##,##0.00")))
                 .Replace("@AUTENTICACAOMECANICA", "")
-                .Replace("@USODOBANCO", boleto.UsoBanco)
+                .Replace("@USODOBANCO", Boleto.UsoBanco)
                 .Replace("@IMAGEMCODIGOBARRA", imagemCodigoBarras)
-                .Replace("@ACEITE", boleto.Aceite).ToString()
+                .Replace("@ACEITE", Boleto.Aceite).ToString()
                 .Replace("@ENDERECOCEDENTE", MostrarEnderecoCedente ? enderecoCedente : "")
-                .Replace("@INSTRUCOES", boleto.MensagemInstrucoesCaixa);
+                .Replace("@INSTRUCOES", Boleto.MensagemInstrucoesCaixa);
         }
 
         #endregion Html
@@ -472,13 +472,13 @@ namespace Boleto2Net
         /// <param name="srcBarra">Local apontado pela imagem de barra.</param>
         /// <param name="srcCodigoBarra">Local apontado pela imagem do código de barras.</param>
         /// <returns>StringBuilder conténdo o código html do boleto bancário.</returns>
-        protected StringBuilder HtmlOffLine(string textoNoComecoDoEmail, string srcLogo, string srcBarra, string srcCodigoBarra, bool usaCSSPDF = false)
+        protected StringBuilder HtmlOffLine(string textoNoComecoDoEmail, string srcLogo, string srcBarra, string srcCodigoBarra, bool usaCsspdf = false)
         {//protected StringBuilder HtmlOffLine(string srcCorte, string srcLogo, string srcBarra, string srcPonto, string srcBarraInterna, string srcCodigoBarra)
-            this.OnLoad(EventArgs.Empty);
+            OnLoad(EventArgs.Empty);
 
-            StringBuilder html = new StringBuilder();
-            HtmlOfflineHeader(html, usaCSSPDF);
-            if (textoNoComecoDoEmail != null && textoNoComecoDoEmail != "")
+            var html = new StringBuilder();
+            HtmlOfflineHeader(html, usaCsspdf);
+            if (!string.IsNullOrEmpty(textoNoComecoDoEmail))
             {
                 html.Append(textoNoComecoDoEmail);
             }
@@ -494,7 +494,7 @@ namespace Boleto2Net
         /// Monta o Header de um email com pelo menos um boleto dentro.
         /// </summary>
         /// <param name="saida">StringBuilder onde o conteudo sera salvo.</param>
-        protected static void HtmlOfflineHeader(StringBuilder html, bool usaCSSPDF = false)
+        protected static void HtmlOfflineHeader(StringBuilder html, bool usaCsspdf = false)
         {
             html.Append("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n");
             html.Append("<html xmlns=\"http://www.w3.org/1999/xhtml\">\n");
@@ -505,10 +505,10 @@ namespace Boleto2Net
 
             #region Css
             {
-                string arquivoCSS = usaCSSPDF ? "Boleto2Net.BoletoImpressao.BoletoNetPDF.css" : "Boleto2Net.BoletoImpressao.BoletoNet.css";
-                Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(arquivoCSS);
+                var arquivoCss = usaCsspdf ? "Boleto2Net.BoletoImpressao.BoletoNetPDF.css" : "Boleto2Net.BoletoImpressao.BoletoNet.css";
+                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(arquivoCss);
 
-                using (StreamReader sr = new StreamReader(stream))
+                using (var sr = new StreamReader(stream))
                 {
                     html.Append("<style>\n");
                     html.Append(sr.ReadToEnd());
@@ -585,7 +585,7 @@ namespace Boleto2Net
 
 
 
-            AlternateView av = AlternateView.CreateAlternateViewFromString(corpoDoEmail.ToString(), Encoding.Default, "text/html");
+            var av = AlternateView.CreateAlternateViewFromString(corpoDoEmail.ToString(), Encoding.Default, "text/html");
             foreach (var theResource in linkedResources)
             {
                 av.LinkedResources.Add(theResource);
@@ -619,9 +619,9 @@ namespace Boleto2Net
             LinkedResource lrImagemCodigoBarra;
 
             GeraGraficosParaEmailOffLine(out lrImagemLogo, out lrImagemBarra, out lrImagemCodigoBarra);
-            StringBuilder html = HtmlOffLine(textoNoComecoDoEmail, "cid:" + lrImagemLogo.ContentId, "cid:" + lrImagemBarra.ContentId, "cid:" + lrImagemCodigoBarra.ContentId);
+            var html = HtmlOffLine(textoNoComecoDoEmail, "cid:" + lrImagemLogo.ContentId, "cid:" + lrImagemBarra.ContentId, "cid:" + lrImagemCodigoBarra.ContentId);
 
-            AlternateView av = AlternateView.CreateAlternateViewFromString(html.ToString(), Encoding.Default, "text/html");
+            var av = AlternateView.CreateAlternateViewFromString(html.ToString(), Encoding.Default, "text/html");
 
             av.LinkedResources.Add(lrImagemLogo);
             av.LinkedResources.Add(lrImagemBarra);
@@ -637,23 +637,23 @@ namespace Boleto2Net
         /// <param name="lrImagemCodigoBarra">O Código de Barras</param>
         void GeraGraficosParaEmailOffLine(out LinkedResource lrImagemLogo, out LinkedResource lrImagemBarra, out LinkedResource lrImagemCodigoBarra)
         {
-            this.OnLoad(EventArgs.Empty);
+            OnLoad(EventArgs.Empty);
 
             var randomSufix = new Random().Next().ToString(); // para podermos colocar no mesmo email varios boletos diferentes
 
-            Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg");
+            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg");
             lrImagemLogo = new LinkedResource(stream, MediaTypeNames.Image.Jpeg)
             {
                 ContentId = "logo" + randomSufix
             };
 
-            MemoryStream ms = new MemoryStream(Utils.ConvertImageToByte(Html.barra));
+            var ms = new MemoryStream(Utils.ConvertImageToByte(Html.barra));
             lrImagemBarra = new LinkedResource(ms, MediaTypeNames.Image.Gif)
             {
                 ContentId = "barra" + randomSufix
             };
 
-            BarCode2of5i cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
+            var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, 1, 50, Boleto.CodigoBarra.CodigoDeBarras.Length);
             ms = new MemoryStream(Utils.ConvertImageToByte(cb.ToBitmap()));
 
             lrImagemCodigoBarra = new LinkedResource(ms, MediaTypeNames.Image.Gif)
@@ -670,9 +670,9 @@ namespace Boleto2Net
         /// <param name="fileName">Path do arquivo que deve conter o código html.</param>
         public void MontaHtmlNoArquivoLocal(string fileName)
         {
-            using (FileStream f = new FileStream(fileName, FileMode.Create))
+            using (var f = new FileStream(fileName, FileMode.Create))
             {
-                StreamWriter w = new StreamWriter(f, System.Text.Encoding.Default);
+                var w = new StreamWriter(f, Encoding.Default);
                 w.Write(MontaHtml());
                 w.Close();
                 f.Close();
@@ -698,30 +698,30 @@ namespace Boleto2Net
         public string MontaHtml(string fileName, string logoCedente)
         {
             if (fileName == null)
-                fileName = System.IO.Path.GetTempPath();
+                fileName = Path.GetTempPath();
 
             if (logoCedente != null)
-                vLocalLogoCedente = logoCedente;
+                _vLocalLogoCedente = logoCedente;
 
-            this.OnLoad(EventArgs.Empty);
+            OnLoad(EventArgs.Empty);
 
-            string fnLogo = fileName + @"BoletoNet" + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg";
+            var fnLogo = fileName + @"BoletoNet" + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg";
 
-            if (!System.IO.File.Exists(fnLogo))
+            if (!File.Exists(fnLogo))
             {
-                Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg");
+                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg");
                 using (Stream file = File.Create(fnLogo))
                 {
                     CopiarStream(stream, file);
                 }
             }
 
-            string fnBarra = fileName + @"BoletoNetBarra.gif";
+            var fnBarra = fileName + @"BoletoNetBarra.gif";
             if (!File.Exists(fnBarra))
             {
-                ImageConverter imgConverter = new ImageConverter();
-                byte[] imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
-                MemoryStream ms = new MemoryStream(imgBuffer);
+                var imgConverter = new ImageConverter();
+                var imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
+                var ms = new MemoryStream(imgBuffer);
 
                 using (Stream stream = File.Create(fnBarra))
                 {
@@ -731,8 +731,8 @@ namespace Boleto2Net
                 }
             }
 
-            string fnCodigoBarras = System.IO.Path.GetTempFileName();
-            BarCode2of5i cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
+            var fnCodigoBarras = Path.GetTempFileName();
+            var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, 1, 50, Boleto.CodigoBarra.CodigoDeBarras.Length);
             cb.ToBitmap().Save(fnCodigoBarras);
 
             //return HtmlOffLine(fnCorte, fnLogo, fnBarra, fnPonto, fnBarraInterna, fnCodigoBarras).ToString();
@@ -762,7 +762,7 @@ namespace Boleto2Net
         public string MontaHtml(string url, string fileName, bool useMapPathSecure = true)
         {
             //Variável para o caminho físico do servidor
-            string pathServer = "";
+            var pathServer = "";
 
             //Verifica se o usuário informou uma url válida
             if (url == null)
@@ -799,17 +799,17 @@ namespace Boleto2Net
             }
 
             //Mantive o padrão 
-            this.OnLoad(EventArgs.Empty);
+            OnLoad(EventArgs.Empty);
 
             //Prepara o arquivo da logo para ser salvo
-            string fnLogo = pathServer + @"BoletoNet" + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg";
+            var fnLogo = pathServer + @"BoletoNet" + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg";
             //Prepara o arquivo da logo para ser usado no html
-            string fnLogoUrl = url + @"BoletoNet" + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg";
+            var fnLogoUrl = url + @"BoletoNet" + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg";
 
             //Salvo a imagem apenas 1 vez com o código do banco
-            if (!System.IO.File.Exists(fnLogo))
+            if (!File.Exists(fnLogo))
             {
-                Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(boleto.Banco.Codigo.ToString(), 3) + ".jpg");
+                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Boleto2Net.Imagens." + Utils.FormatCode(Boleto.Banco.Codigo.ToString(), 3) + ".jpg");
                 using (Stream file = File.Create(fnLogo))
                 {
                     CopiarStream(stream, file);
@@ -817,16 +817,16 @@ namespace Boleto2Net
             }
 
             //Prepara o arquivo da barra para ser salvo
-            string fnBarra = pathServer + @"BoletoNetBarra.gif";
+            var fnBarra = pathServer + @"BoletoNetBarra.gif";
             //Prepara o arquivo da barra para ser usado no html
-            string fnBarraUrl = url + @"BoletoNetBarra.gif";
+            var fnBarraUrl = url + @"BoletoNetBarra.gif";
 
             //Salvo a imagem apenas 1 vez
             if (!File.Exists(fnBarra))
             {
-                ImageConverter imgConverter = new ImageConverter();
-                byte[] imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
-                MemoryStream ms = new MemoryStream(imgBuffer);
+                var imgConverter = new ImageConverter();
+                var imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
+                var ms = new MemoryStream(imgBuffer);
 
                 using (Stream stream = File.Create(fnBarra))
                 {
@@ -837,11 +837,11 @@ namespace Boleto2Net
             }
 
             //Prepara o arquivo do código de barras para ser salvo
-            string fnCodigoBarras = string.Format("{0}{1}_codigoBarras.jpg", pathServer, fileName);
+            var fnCodigoBarras = string.Format("{0}{1}_codigoBarras.jpg", pathServer, fileName);
             //Prepara o arquivo do código de barras para ser usado no html
-            string fnCodigoBarrasUrl = string.Format("{0}{1}_codigoBarras.jpg", url, fileName);
+            var fnCodigoBarrasUrl = string.Format("{0}{1}_codigoBarras.jpg", url, fileName);
 
-            BarCode2of5i cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
+            var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, 1, 50, Boleto.CodigoBarra.CodigoDeBarras.Length);
 
             //Salva o arquivo conforme o fileName
             cb.ToBitmap().Save(fnCodigoBarras);
@@ -860,38 +860,38 @@ namespace Boleto2Net
         /// <criacao>23/01/2014</criacao>
         /// <alteracao>08/08/2014</alteracao>
 
-        public string MontaHtmlEmbedded(bool convertLinhaDigitavelToImage = false, bool usaCSSPDF = false)
+        public string MontaHtmlEmbedded(bool convertLinhaDigitavelToImage = false, bool usaCsspdf = false)
         {
             OnLoad(EventArgs.Empty);
 
             var assembly = Assembly.GetExecutingAssembly();
 
-            var streamLogo = assembly.GetManifestResourceStream("Boleto2Net.Imagens." + boleto.Banco.Codigo.ToString("000") + ".jpg");
-            string base64Logo = Convert.ToBase64String(new BinaryReader(streamLogo).ReadBytes((int)streamLogo.Length));
-            string fnLogo = string.Format("data:image/gif;base64,{0}", base64Logo);
+            var streamLogo = assembly.GetManifestResourceStream("Boleto2Net.Imagens." + Boleto.Banco.Codigo.ToString("000") + ".jpg");
+            var base64Logo = Convert.ToBase64String(new BinaryReader(streamLogo).ReadBytes((int)streamLogo.Length));
+            var fnLogo = string.Format("data:image/gif;base64,{0}", base64Logo);
 
             var streamBarra = assembly.GetManifestResourceStream("Boleto2Net.Imagens.barra.gif");
-            string base64Barra = Convert.ToBase64String(new BinaryReader(streamBarra).ReadBytes((int)streamBarra.Length));
-            string fnBarra = string.Format("data:image/gif;base64,{0}", base64Barra);
+            var base64Barra = Convert.ToBase64String(new BinaryReader(streamBarra).ReadBytes((int)streamBarra.Length));
+            var fnBarra = string.Format("data:image/gif;base64,{0}", base64Barra);
 
-            var cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
-            string base64CodigoBarras = Convert.ToBase64String(cb.ToByte());
-            string fnCodigoBarras = string.Format("data:image/gif;base64,{0}", base64CodigoBarras);
+            var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, 1, 50, Boleto.CodigoBarra.CodigoDeBarras.Length);
+            var base64CodigoBarras = Convert.ToBase64String(cb.ToByte());
+            var fnCodigoBarras = string.Format("data:image/gif;base64,{0}", base64CodigoBarras);
 
             if (convertLinhaDigitavelToImage)
             {
 
-                string linhaDigitavel = boleto.CodigoBarra.LinhaDigitavel.Replace("  ", " ").Trim();
+                var linhaDigitavel = Boleto.CodigoBarra.LinhaDigitavel.Replace("  ", " ").Trim();
 
                 var imagemLinha = Utils.DrawText(linhaDigitavel, new Font("Arial", 30, FontStyle.Bold), Color.Black, Color.White);
-                string base64Linha = Convert.ToBase64String(Utils.ConvertImageToByte(imagemLinha));
+                var base64Linha = Convert.ToBase64String(Utils.ConvertImageToByte(imagemLinha));
 
-                string fnLinha = string.Format("data:image/gif;base64,{0}", base64Linha);
+                var fnLinha = string.Format("data:image/gif;base64,{0}", base64Linha);
 
-                boleto.CodigoBarra.LinhaDigitavel = @"<img style=""max-width:420px; margin-bottom: 2px"" src=" + fnLinha + " />";
+                Boleto.CodigoBarra.LinhaDigitavel = @"<img style=""max-width:420px; margin-bottom: 2px"" src=" + fnLinha + " />";
             }
 
-            string s = HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras, usaCSSPDF).ToString();
+            var s = HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras, usaCsspdf).ToString();
 
             if (convertLinhaDigitavelToImage)
             {
@@ -904,20 +904,20 @@ namespace Boleto2Net
         public byte[] MontaBytesPDF(bool convertLinhaDigitavelToImage = false)
         {
 
-            return (new NReco.PdfGenerator.HtmlToPdfConverter()).GeneratePdf(this.MontaHtmlEmbedded(convertLinhaDigitavelToImage, true));
+            return (new NReco.PdfGenerator.HtmlToPdfConverter()).GeneratePdf(MontaHtmlEmbedded(convertLinhaDigitavelToImage, true));
         }
         #endregion Geração do Html OffLine
 
-        public System.Drawing.Image GeraImagemCodigoBarras(Boleto boleto)
+        public Image GeraImagemCodigoBarras(Boleto boleto)
         {
-            BarCode2of5i cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
+            var cb = new BarCode2of5i(boleto.CodigoBarra.CodigoDeBarras, 1, 50, boleto.CodigoBarra.CodigoDeBarras.Length);
             return cb.ToBitmap();
         }
 
         private void CopiarStream(Stream entrada, Stream saida)
         {
-            int bytesLidos = 0;
-            byte[] imgBuffer = new byte[entrada.Length];
+            var bytesLidos = 0;
+            var imgBuffer = new byte[entrada.Length];
 
             while ((bytesLidos = entrada.Read(imgBuffer, 0, imgBuffer.Length)) > 0)
             {

--- a/Boleto2.Net/Enums/TipoEspecieDocumento.cs
+++ b/Boleto2.Net/Enums/TipoEspecieDocumento.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace Boleto2Net
+﻿namespace Boleto2Net
 {
     public enum TipoEspecieDocumento
     {

--- a/Boleto2.Net/Extensions/DateTimeExtensions.cs
+++ b/Boleto2.Net/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+namespace Boleto2Net.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        ///     Fator de vencimento do boleto.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns>Retorno Fator de Vencimento</returns>
+        /// <remarks>
+        ///     Wellington(wcarvalho@novatela.com.br)
+        ///     Com base na proposta feita pela CENEGESC de acordo com o comunicado FEBRABAN de n° 082/2012 de 14/06/2012 segue
+        ///     regra para implantação.
+        ///     No dia 21/02/2025 o fator vencimento chegará em 9999 assim atigindo o tempo de utilização, para contornar esse
+        ///     problema foi definido com uma nova regra
+        ///     de utilizaçao criando um range de uso o range funcionara controlando a emissão dos boletos.
+        ///     Exemplo:
+        ///     Data Atual: 12/03/2014 = 6000
+        ///     Para os boletos vencidos, anterior a data atual é de 3000 fatores cerca de =/- 8 anos. Os boletos que forem gerados
+        ///     acima dos 3000 não serão aceitos pelas instituições financeiras.
+        ///     Para os boletos a vencer, posterior a data atual é de 5500 fatores cerca de +/- 15 anos. Os boletos que forem
+        ///     gerados acima dos 5500 não serão aceitos pelas instituições financeiras.
+        ///     Quando o fator de vencimento atingir 9999 ele retorna para 1000
+        ///     Exemplo:
+        ///     21/02/2025 = 9999
+        ///     22/02/2025 = 1000
+        ///     23/02/2025 = 1001
+        ///     ...
+        ///     05/03/2025 = 1011
+        /// </remarks>
+        public static long FatorVencimento(this DateTime data)
+        {
+            var dateBase = new DateTime(1997, 10, 7, 0, 0, 0);
+
+            // Verifica se a data esta dentro do range utilizavel
+            var rangeUtilizavel = DateTime.Now.Date.DateDiff(data, DateInterval.Day);
+
+            if (rangeUtilizavel > 5500 || rangeUtilizavel < -3000)
+                throw new Exception("Data do vencimento fora do range de utilização proposto pela CENEGESC. Comunicado FEBRABAN de n° 082/2012 de 14/06/2012");
+
+            while (data > dateBase.AddDays(9999))
+                dateBase = data.AddDays(-(dateBase.DateDiff(data, DateInterval.Day) - 9999 - 1 + 1000));
+
+            return dateBase.DateDiff(data, DateInterval.Day);
+        }
+
+        internal static long DateDiff(this DateTime startDate, DateTime endDate, DateInterval interval)
+        {
+            var timeSpan = endDate - startDate;
+            switch (interval)
+            {
+                case DateInterval.Day:
+                    return timeSpan.Days;
+                case DateInterval.Hour:
+                    return (long)timeSpan.TotalHours;
+                case DateInterval.Minute:
+                    return (long)timeSpan.TotalMinutes;
+                case DateInterval.Month:
+                    return timeSpan.Days / 30;
+                case DateInterval.Quarter:
+                    return (timeSpan.Days / 30) / 3;
+                case DateInterval.Second:
+                    return (long)timeSpan.TotalSeconds;
+                case DateInterval.Week:
+                    return timeSpan.Days / 7;
+                case DateInterval.Year:
+                    return timeSpan.Days / 365;
+                default:
+                    throw new ArgumentException("Intervalo não suportado");
+            }
+        }
+
+    }
+}

--- a/Boleto2.Net/Util/BarCode2of5i.cs
+++ b/Boleto2.Net/Util/BarCode2of5i.cs
@@ -6,11 +6,11 @@ namespace Boleto2Net
     public class BarCode2of5i : BarCodeBase
     {
         #region variables
-        private string[] cPattern = new string[100];
+        private readonly string[] _cPattern = new string[100];
         private const string START = "0000";
         private const string STOP = "1000";
-        private Bitmap bitmap;
-        private Graphics g;
+        private Bitmap _bitmap;
+        private Graphics _g;
         #endregion
 
         #region Constructor
@@ -20,28 +20,28 @@ namespace Boleto2Net
         /// <summary>
         /// Code 2 of 5 intrelaced Constructor
         /// </summary>
-        /// <param name="Code">The string that contents the numeric code</param>
-        /// <param name="BarWidth">The Width of each bar</param>
-        /// <param name="Height">The Height of each bar</param>
-        public BarCode2of5i(string Code, int BarWidth, int Height)
+        /// <param name="code">The string that contents the numeric code</param>
+        /// <param name="barWidth">The Width of each bar</param>
+        /// <param name="height">The Height of each bar</param>
+        public BarCode2of5i(string code, int barWidth, int height)
         {
-            this.Code = Code;
-            this.Height = Height;
-            this.Width = BarWidth;
+            Code = code;
+            Height = height;
+            Width = barWidth;
         }
         /// <summary>
         /// Code 2 of 5 intrelaced Constructor
         /// </summary>
-        /// <param name="Code">The string that contents the numeric code</param>
-        /// <param name="BarWidth">The Width of each bar</param>
-        /// <param name="Height">The Height of each bar</param>
-        /// <param name="Digits">Number of digits of code</param>
-        public BarCode2of5i(string Code, int BarWidth, int Height, int Digits)
+        /// <param name="code">The string that contents the numeric code</param>
+        /// <param name="barWidth">The Width of each bar</param>
+        /// <param name="height">The Height of each bar</param>
+        /// <param name="digits">Number of digits of code</param>
+        public BarCode2of5i(string code, int barWidth, int height, int digits)
         {
-            this.Code = Code;
-            this.Height = Height;
-            this.Width = BarWidth;
-            this.Digits = Digits;
+            Code = code;
+            Height = height;
+            Width = barWidth;
+            Digits = digits;
         }
         #endregion
 
@@ -50,18 +50,18 @@ namespace Boleto2Net
             int f;
             string strTemp;
 
-            if (cPattern[0] == null)
+            if (_cPattern[0] == null)
             {
-                cPattern[0] = "00110";
-                cPattern[1] = "10001";
-                cPattern[2] = "01001";
-                cPattern[3] = "11000";
-                cPattern[4] = "00101";
-                cPattern[5] = "10100";
-                cPattern[6] = "01100";
-                cPattern[7] = "00011";
-                cPattern[8] = "10010";
-                cPattern[9] = "01010";
+                _cPattern[0] = "00110";
+                _cPattern[1] = "10001";
+                _cPattern[2] = "01001";
+                _cPattern[3] = "11000";
+                _cPattern[4] = "00101";
+                _cPattern[5] = "10100";
+                _cPattern[6] = "01100";
+                _cPattern[7] = "00011";
+                _cPattern[8] = "10010";
+                _cPattern[9] = "01010";
                 //Create a draw pattern for each char from 0 to 99
                 for (int f1 = 9; f1 >= 0; f1--)
                 {
@@ -71,10 +71,10 @@ namespace Boleto2Net
                         var builder = new System.Text.StringBuilder();
                         for (int i = 0; i < 5; i++)
                         {
-                            builder.Append(cPattern[f1][i].ToString() + cPattern[f2][i].ToString());
+                            builder.Append(_cPattern[f1][i] + _cPattern[f2][i].ToString());
                         }
                         strTemp = builder.ToString();
-                        cPattern[f] = strTemp;
+                        _cPattern[f] = strTemp;
                     }
                 }
             }
@@ -85,49 +85,45 @@ namespace Boleto2Net
         /// <returns>Return System.Drawing.Bitmap</returns>
         public Bitmap ToBitmap()
         {
-            int i;
-            string ftemp;
+            XPos = 0;
+            YPos = 0;
 
-            xPos = 0;
-            yPos = 0;
-
-            if (this.Digits == 0)
+            if (Digits == 0)
             {
-                this.Digits = this.Code.Length;
+                Digits = Code.Length;
             }
 
-            if (this.Digits % 2 > 0) this.Digits++;
+            if (Digits % 2 > 0) Digits++;
 
-            while (this.Code.Length < this.Digits || this.Code.Length % 2 > 0)
+            while (Code.Length < Digits || Code.Length % 2 > 0)
             {
-                this.Code = "0" + this.Code;
+                Code = "0" + Code;
             }
 
-            int _width = (2 * Full + 3 * Thin) * (Digits) + 7 * Thin + Full;
+            int width = (2 * Full + 3 * Thin) * (Digits) + 7 * Thin + Full;
 
-            bitmap = new Bitmap(_width, Height);
-            g = Graphics.FromImage(bitmap);
+            _bitmap = new Bitmap(width, Height);
+            _g = Graphics.FromImage(_bitmap);
 
             //Start Pattern
-            DrawPattern(ref g, START);
+            DrawPattern(ref _g, START);
 
             //Draw code
-            this.FillPatern();
-            while (this.Code.Length > 0)
+            FillPatern();
+            while (Code.Length > 0)
             {
-                i = Convert.ToInt32(this.Code.Substring(0, 2));
-                if (this.Code.Length > 2)
-                    this.Code = this.Code.Substring(2, this.Code.Length - 2);
+                var i = Convert.ToInt32(Code.Substring(0, 2));
+                if (Code.Length > 2)
+                    Code = Code.Substring(2, Code.Length - 2);
                 else
-                    this.Code = "";
-                ftemp = cPattern[i];
-                DrawPattern(ref g, ftemp);
+                    Code = "";
+                DrawPattern(ref _g, _cPattern[i]);
             }
 
             //Stop Patern
-            DrawPattern(ref g, STOP);
+            DrawPattern(ref _g, STOP);
 
-            return bitmap;
+            return _bitmap;
         }
         /// <summary>
         /// Returns the byte array of Barcode
@@ -135,7 +131,7 @@ namespace Boleto2Net
         /// <returns>byte[]</returns>
         public byte[] ToByte()
         {
-            return base.toByte(ToBitmap());
+            return base.ToByte(ToBitmap());
         }
     }
 }

--- a/Boleto2.Net/Util/BarCodeBase.cs
+++ b/Boleto2.Net/Util/BarCodeBase.cs
@@ -15,13 +15,13 @@ namespace Boleto2Net
         private int _thin;
         private int _full;
 
-        protected int xPos = 0;
-        protected int yPos = 0;
+        protected int XPos = 0;
+        protected int YPos = 0;
 
         private string _contenttype;
 
-        protected Brush BLACK = Brushes.Black;
-        protected Brush WHITE = Brushes.White;
+        protected Brush Black = Brushes.Black;
+        protected Brush White = Brushes.White;
 
         #endregion
 
@@ -203,7 +203,7 @@ namespace Boleto2Net
             }
         }
         #endregion
-        protected virtual byte[] toByte(Bitmap bitmap)
+        protected virtual byte[] ToByte(Bitmap bitmap)
         {
             MemoryStream mstream = new MemoryStream();
             ImageCodecInfo myImageCodecInfo = GetEncoderInfo(ContentType);
@@ -228,23 +228,23 @@ namespace Boleto2Net
             }
             return null;
         }
-        protected virtual void DrawPattern(ref Graphics g, string Pattern)
+        protected virtual void DrawPattern(ref Graphics g, string pattern)
         {
             int tempWidth;
 
-            for (int i = 0; i < Pattern.Length; i++)
+            for (int i = 0; i < pattern.Length; i++)
             {
-                if (Pattern[i] == '0')
+                if (pattern[i] == '0')
                     tempWidth = _thin;
                 else
                     tempWidth = _full;
 
                 if (i % 2 == 0)
-                    g.FillRectangle(BLACK, xPos, yPos, tempWidth, _height);
+                    g.FillRectangle(Black, XPos, YPos, tempWidth, _height);
                 else
-                    g.FillRectangle(WHITE, xPos, yPos, tempWidth, _height);
+                    g.FillRectangle(White, XPos, YPos, tempWidth, _height);
 
-                xPos += tempWidth;
+                XPos += tempWidth;
             }
         }
     }

--- a/Boleto2.Net/Util/Utils.cs
+++ b/Boleto2.Net/Util/Utils.cs
@@ -1,50 +1,15 @@
 using System;
-using System.Globalization;
-using System.Drawing;
 using System.ComponentModel;
+using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 
 namespace Boleto2Net
 {
     sealed class Utils
     {
-        internal static long DateDiff(DateInterval Interval, System.DateTime StartDate, System.DateTime EndDate)
-        {
-            long lngDateDiffValue = 0;
-            System.TimeSpan TS = new System.TimeSpan(EndDate.Ticks - StartDate.Ticks);
-            switch (Interval)
-            {
-                case DateInterval.Day:
-                    lngDateDiffValue = (long)TS.Days;
-                    break;
-                case DateInterval.Hour:
-                    lngDateDiffValue = (long)TS.TotalHours;
-                    break;
-                case DateInterval.Minute:
-                    lngDateDiffValue = (long)TS.TotalMinutes;
-                    break;
-                case DateInterval.Month:
-                    lngDateDiffValue = (long)(TS.Days / 30);
-                    break;
-                case DateInterval.Quarter:
-                    lngDateDiffValue = (long)((TS.Days / 30) / 3);
-                    break;
-                case DateInterval.Second:
-                    lngDateDiffValue = (long)TS.TotalSeconds;
-                    break;
-                case DateInterval.Week:
-                    lngDateDiffValue = (long)(TS.Days / 7);
-                    break;
-                case DateInterval.Year:
-                    lngDateDiffValue = (long)(TS.Days / 365);
-                    break;
-            }
-            return (lngDateDiffValue);
-        }
-        internal static string FormatCode(string text, int length)
-        {
-            return text.PadLeft(length, '0');
-        }
+        internal static string FormatCode(string text, int length) => text.PadLeft(length, '0');
+
         internal static bool ToBool(object value)
         {
             try
@@ -56,6 +21,7 @@ namespace Boleto2Net
                 return false;
             }
         }
+
         internal static int ToInt32(string value)
         {
             try
@@ -67,6 +33,7 @@ namespace Boleto2Net
                 return 0;
             }
         }
+
         internal static long ToInt64(string value)
         {
             try
@@ -78,6 +45,7 @@ namespace Boleto2Net
                 return 0;
             }
         }
+
         internal static string ToString(object value)
         {
             try
@@ -89,6 +57,7 @@ namespace Boleto2Net
                 return string.Empty;
             }
         }
+
         internal static DateTime ToDateTime(object value)
         {
             try
@@ -100,6 +69,7 @@ namespace Boleto2Net
                 return new DateTime(1, 1, 1);
             }
         }
+
         public static T ToEnum<T>(string value, bool ignoreCase, T defaultValue) where T : struct
         {
             if (string.IsNullOrEmpty(value))
@@ -121,10 +91,10 @@ namespace Boleto2Net
         {
             if (value.Trim().Length == 11)
                 return FormataCPF(value);
-            else if (value.Trim().Length == 14)
+            if (value.Trim().Length == 14)
                 return FormataCNPJ(value);
 
-            throw new Exception(string.Format("O CPF ou CNPJ: {0} é inválido.", value));
+            throw new Exception($"O CPF ou CNPJ: {value} é inválido.");
         }
 
         /// <summary>
@@ -136,7 +106,7 @@ namespace Boleto2Net
         {
             try
             {
-                return string.Format("{0}.{1}.{2}-{3}", cpf.Substring(0, 3), cpf.Substring(3, 3), cpf.Substring(6, 3), cpf.Substring(9, 2));
+                return $"{cpf.Substring(0, 3)}.{cpf.Substring(3, 3)}.{cpf.Substring(6, 3)}-{cpf.Substring(9, 2)}";
             }
             catch (Exception ex)
             {
@@ -153,7 +123,7 @@ namespace Boleto2Net
         {
             try
             {
-                return string.Format("{0}.{1}.{2}/{3}-{4}", cnpj.Substring(0, 2), cnpj.Substring(2, 3), cnpj.Substring(5, 3), cnpj.Substring(8, 4), cnpj.Substring(12, 2));
+                return $"{cnpj.Substring(0, 2)}.{cnpj.Substring(2, 3)}.{cnpj.Substring(5, 3)}/{cnpj.Substring(8, 4)}-{cnpj.Substring(12, 2)}";
             }
             catch (Exception ex)
             {
@@ -170,7 +140,7 @@ namespace Boleto2Net
         {
             try
             {
-                return string.Format("{0}{1}-{2}", cep.Substring(0, 2), cep.Substring(2, 3), cep.Substring(5, 3));
+                return $"{cep.Substring(0, 2)}{cep.Substring(2, 3)}-{cep.Substring(5, 3)}";
             }
             catch (Exception ex)
             {
@@ -181,7 +151,7 @@ namespace Boleto2Net
         /// <summary>
         /// Formata o campo de acordo com o tipo e o tamanho 
         /// </summary>        
-        public static string FitStringLength(string SringToBeFit, int maxLength, int minLength, char FitChar, int maxStartPosition, bool maxTest, bool minTest, bool isNumber)
+        public static string FitStringLength(string sringToBeFit, int maxLength, int minLength, char fitChar, int maxStartPosition, bool maxTest, bool minTest, bool isNumber)
         {
             try
             {
@@ -190,24 +160,24 @@ namespace Boleto2Net
                 if (maxTest == true)
                 {
                     // max
-                    if (SringToBeFit.Length > maxLength)
+                    if (sringToBeFit.Length > maxLength)
                     {
-                        result += SringToBeFit.Substring(maxStartPosition, maxLength);
+                        result += sringToBeFit.Substring(maxStartPosition, maxLength);
                     }
                 }
 
                 if (minTest == true)
                 {
                     // min
-                    if (SringToBeFit.Length <= minLength)
+                    if (sringToBeFit.Length <= minLength)
                     {
                         if (isNumber == true)
                         {
-                            result += (string)(new string(FitChar, (minLength - SringToBeFit.Length)) + SringToBeFit);
+                            result += (string)(new string(fitChar, (minLength - sringToBeFit.Length)) + sringToBeFit);
                         }
                         else
                         {
-                            result += (string)(SringToBeFit + new string(FitChar, (minLength - SringToBeFit.Length)));
+                            result += (string)(sringToBeFit + new string(fitChar, (minLength - sringToBeFit.Length)));
                         }
                     }
                 }
@@ -215,10 +185,11 @@ namespace Boleto2Net
             }
             catch (Exception ex)
             {
-                Exception tmpEx = new Exception("Problemas ao Formatar a string. String = " + SringToBeFit, ex);
+                Exception tmpEx = new Exception("Problemas ao Formatar a string. String = " + sringToBeFit, ex);
                 throw tmpEx;
             }
         }
+
         public static string SubstituiCaracteresEspeciais(string strline)
         {
             try
@@ -287,6 +258,7 @@ namespace Boleto2Net
             else
                 throw new NotImplementedException("ConvertImageToByte invalid type " + image.GetType().ToString());
         }
+
         internal static Image DrawText(string text, Font font, Color textColor, Color backColor)
         {
             //first, create a dummy bitmap just to get a graphics object
@@ -320,6 +292,5 @@ namespace Boleto2Net
 
             return img;
         }
-
     }
 }


### PR DESCRIPTION
- Usando NUnit ao invés de MSTest, além disso foram refatorado alguns testes para remover boa parte da duplicação de código.
- Foi ajustado o nome de variáveis, método e classe para ficar adequado com o padrão do C#
- Remoção de algumas palavras reservadas que eram de desnecessárias em algumas linhas, como this
- Criado DateTimeExtensions